### PR TITLE
Wall controls: only mount on a door's face when they share the same wall (fix lever on secret door SE L3 )

### DIFF
--- a/Assets/Game/Scripts/UUObject.cs
+++ b/Assets/Game/Scripts/UUObject.cs
@@ -597,11 +597,21 @@ public class UUObject : LevelObject
         }
 
         Door door = FindDoorOnTile(initialTile);
-        bool doorSharesWallAxis = door != null
+        // Sharing an axis is not enough: north and south are the same axis but opposite edges of
+        // the tile, and a control on one of them has nothing to do with a door on the other. The
+        // sub tile coordinate says which edge each of them is actually on - 0 to 3 is the low
+        // side, 4 to 7 the high side - so require them to agree before treating the door's face
+        // as the surface to mount on.
+        // Without this, the lever in the secret door niche on level 3 (tile 52,13: door at y = 0
+        // facing south, lever at y = 7 facing north) is dragged three metres across the tile onto
+        // the outside of the door, and ends up hanging in the corridor once the niche opens.
+        bool doorSharesWall = door != null
             && ((angle == 0 || angle == 4) && (door.angle == 0 || door.angle == 4)
-                || (angle == 2 || angle == 6) && (door.angle == 2 || door.angle == 6));
+                    && SameTileEdge(y, door.y)
+                || (angle == 2 || angle == 6) && (door.angle == 2 || door.angle == 6)
+                    && SameTileEdge(x, door.x));
 
-        if (doorSharesWallAxis)
+        if (doorSharesWall)
         {
             // Match Door.CreateDoorGeometry frame half-thickness. Forward points into the wall, so the
             // readable face is on the opposite side of the door center (away along -forward).
@@ -647,6 +657,15 @@ public class UUObject : LevelObject
     /// Finds a door on the tile. Prefers <see cref="Tile.door"/> when already set; otherwise walks the
     /// object chain (needed when this runs before Door.PostLoadInitialize assigns the tile reference).
     /// </summary>
+    /// <summary>
+    /// Whether two sub tile coordinates fall on the same half of the tile, and so on the same
+    /// wall of the pair that share an axis.
+    /// </summary>
+    private static bool SameTileEdge(int a, int b)
+    {
+        return (a < 4) == (b < 4);
+    }
+
     private static Door FindDoorOnTile(Tile tile)
     {
         if (tile == null)


### PR DESCRIPTION
SnapToWallUsingTileBoundaries lines a switch, lever, pull chain, button or piece of writing up with a door on the same tile, so a control mounted on a door sits on the door's face rather than on the tile boundary behind it. Its test for "same wall" only checked that the two share an axis, and north and south are the same axis while being opposite sides of the tile. The sub tile coordinate already says which edge each object is on, 0 to 3 the low side and 4 to 7 the high side, so this requires those to agree as well.

The visible symptom is the lever in the secret door niche on level 3. It belongs on the back wall of the niche and was being snapped three metres across the tile onto the outside of the door, where it hangs in mid air over the concealing decal once the niche opens.

Details
-------

Tile (52,13) holds the secret door #589 at sub tile y = 0 facing south, and the lever #972 at y = 7 facing north, on the far side of the same block. Both are on the north-south axis, so the old test matched and the lever was moved to doorFace.z = 39.000 - the wall the decal is painted on - instead of staying at the north edge, 42.000. While the niche is shut the lever is inside the wall and invisible; open it and it is left in the corridor, above the decal, rather than on the back wall where the level data puts it.

Scanning all nine levels of lev.ark for a wall control and a door sharing a tile and an axis turns up four pairs, and this changes exactly one of them:

    level 3  tile (52,13)  lever #972      + secret door #589        moved
    level 5  tile (57, 2)  writing #481    + open portcullis #674    unchanged
    level 5  tile (53, 5)  writing #671    + door #676               unchanged
    level 7  tile (52,54)  writing #1003   + door #863               unchanged

The other three are writing on a door with sub tile coordinates that genuinely do agree - the case the branch was written for - and they take the same path as before. The remaining 119 wall controls in the game never meet a door on their own tile and do not reach this branch at all.

Worth noting that the three unchanged pairs are only unaffected because they are writing rather than controls. A button placed on the far face of a door would land in the same trap.

Existing saves keep the old position: object positions are serialised, and SwitchBase.PostLoadInitialize deliberately skips its adjustments when restoring from a save, so only a level entered fresh picks the corrected placement up.

This does not touch the separate problem with the emerald puzzle buttons on level 6 that the comment above skPartial mentions. Those two sit at tile corners on sloped tiles with no door involved, and take the other branch.