### PR TITLE
Fix missing armour protection from enchanted items

### DIFF
--- a/Assets/Game/Scripts/Magic.cs
+++ b/Assets/Game/Scripts/Magic.cs
@@ -503,23 +503,35 @@ public class Magic : MonoBehaviour
         permanentSpells.Clear();
     }
 
+    private static int GetSpellArmourValue(int spell)
+    {
+        switch (spells[spell].runes)
+        {
+        case "BIS":
+            return 10;
+        case "IS":
+            return 15;
+        case "IVS":
+            return 20;
+        }
+
+        return 0;
+    }
+
     public int GetSpellArmourScore()
     {
+        // the shield spells are one family, so the strongest wins - they never add up
         int armour = 0;
         foreach (SActiveSpell s in activeSpells)
         {
-            switch (spells[s.spell].runes)
-            {
-            case "BIS":
-                armour += 10;
-                break;
-            case "IS":
-                armour += 15;
-                break;
-            case "IVS":
-                armour += 20;
-                break;
-            }
+            armour = Mathf.Max(armour, GetSpellArmourValue(s.spell));
+        }
+
+        // enchanted items worn are held in permanentSpells, not activeSpells,
+        // so they have to be counted here too - see IsSpellActive()
+        foreach (SPermanentSpell s in permanentSpells)
+        {
+            armour = Mathf.Max(armour, GetSpellArmourValue((int)s.spell));
         }
 
         return armour;


### PR DESCRIPTION
Magic.GetSpellArmourScore() only walked activeSpells. The spells granted by worn enchanted items live in permanentSpells, so an item of Resist Blows or Thick Skin gave no protection at all - while the magic panel drew its icon and Magic.IsSpellActive() reported it up. Five items in the original data are affected.

Shield spells no longer add together either: the strongest wins, cast or worn.

Details
-------

Affected items, from LEV.ARK:

    level  index  item             enchantment   bonus
        3    572  red ring         Resist Blows    +10
        4    591  leather cap      Resist Blows    +10
        8    737  tower shield     Resist Blows    +10
        8    846  breastplate      Resist Blows    +10
        8    784  plate gauntlets  Thick Skin      +15

Taking the strongest follows similarSpells, which already treats IVS/IS/BIS as one family where the stronger replaces the weaker. That replacement only runs once activeSpells is full, so two cast shield spells used to stack.

Iron Flesh ("IVS") is not in EquipEnchantedItem()'s permanent list and no item carries it, so it still only comes from casting.

No save impact: permanentSpells is not serialized, and SaveGameManager rebuilds it by calling Equip() on each equipped item.