### PR TITLE
Critter: restore the original's damage scale and use of all three attacks

### DIFF
--- a/Assets/Game/Scripts/Critter.cs
+++ b/Assets/Game/Scripts/Critter.cs
@@ -700,10 +700,56 @@ public class Critter : UUObject
 
     private ObjectsData.CritterData stats => DataLoader.sDataLoader.objectsData.critterStats[(int)type & 63];
 
-    // for now just use first attack value. not sure how we determine which, if there are options
-    private int attackChanceToHit => stats.AttackChanceToHit[0];
+    /// <summary>
+    /// Attack charge scale from the original executable, sixteen entries at 0x5619:0000 in UW1
+    /// and 0x609e:0000 in UW2. The creature builds charge while it winds up and the strike
+    /// multiplies its rolled damage by scale / 128, from 0.39x uncharged to 1.99x fully wound up.
+    /// </summary>
+    private static readonly int[] attackChargeScale =
+    {
+        50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 155, 170, 185, 205, 230, 255
+    };
 
-    private int attackDamage => stats.AttackDamage[0];
+    private int attackIndex;
+
+    /// <summary>
+    /// Charge the creature built before it committed to the swing. A creature within reach spends
+    /// each tick either starting an attack - one chance in four, which picks the attack, writes
+    /// the action code and begins the swing - or building charge; the blow then clears it. So the
+    /// charge at the blow is the run of ticks before that one in four came up: a geometric draw
+    /// with a mean of 3, capped at the top of the table.
+    /// </summary>
+    private int RollAttackCharge()
+    {
+        int charge = 0;
+        while (charge < attackChargeScale.Length - 1 && Random.value >= 0.25f)
+        {
+            ++charge;
+        }
+
+        return charge;
+    }
+
+    private int attackChanceToHit => stats.AttackChanceToHit[attackIndex];
+
+    private int attackDamage => stats.AttackDamage[attackIndex];
+
+    /// <summary>
+    /// Weighted roulette over the three attacks, the way the original does it: the probability
+    /// bytes of the triple sum to 100 for every creature in the data.
+    /// </summary>
+    private void ChooseAttack()
+    {
+        int ticket = Random.Range(0, 100);
+        for (attackIndex = 0; attackIndex < 2; ++attackIndex)
+        {
+            if (stats.AttackProbability[attackIndex] > ticket)
+            {
+                return;
+            }
+            ticket -= stats.AttackProbability[attackIndex];
+        }
+    }
 
     private int strength => (int)(stats.Strength * curseMultiplier);
 
@@ -1361,14 +1407,17 @@ public class Critter : UUObject
             break;
         case EState.Attack:
             // slot is determined by caller
+            ChooseAttack();
             {
-            // for now choose one randomly from available options
+            // The animation slot is the attack: 1 is bash, 2 slash, 3 thrust, one per row of the
+            // triple. Fall back only when the creature has no frames for the one the data chose.
             List<int> slots = new List<int>();
-            // = bash, 2 = slash, 3 = thrust
             if (crit.frameCount[1] > 0) slots.Add(1);
             if (crit.frameCount[2] > 0) slots.Add(2);
             if (crit.frameCount[3] > 0) slots.Add(3);
-            slot = slots.Count == 1 ? slots[0] : slots[Random.Range(0, slots.Count - 1)];
+            slot = crit.frameCount[attackIndex + 1] > 0
+                ? attackIndex + 1
+                : (slots.Count > 0 ? slots[Random.Range(0, slots.Count)] : 0);
             }
             ChangeAnimation("Attack");
             stateTime = 1.0f; // one second is more time for the player to dodge
@@ -3307,7 +3356,8 @@ public class Critter : UUObject
     int CalcFlankingBonus()
     {
         // base on where attacking the player from
-        // should be 0-3
+        // The original folds the difference between the two headings to 0-4 and adds it both to
+        // the attack score and to the damage, the latter after the charge scale. Still a stub.
         return 0;
     }
 
@@ -3335,9 +3385,11 @@ public class Critter : UUObject
             return;
         }
 
+        // The attack score matches the original: the chosen attack's chance-to-hit byte plus half
+        // the equipment-damage byte plus a roll. The original's roll is rand() % 6 + 7, which
+        // reaches 12; Random.Range stops one short of its bound.
         int flankingbonus = CalcFlankingBonus();
-        int attackScore = attackChanceToHit + (equipDamage / 2) + Random.Range(7, 12) + flankingbonus; //+Maybe Npc Level
-        // + unknownbonus (stored in critterdata)
+        int attackScore = attackChanceToHit + (equipDamage / 2) + Random.Range(7, 13) + flankingbonus;
 
         int defenceScore = attackTarget == null ? PlayerObject.Player.GetDefence() : attackTarget.GetDefence();
 
@@ -3353,17 +3405,14 @@ public class Critter : UUObject
             damage = GetCriticalDamage(damage);
         }
 
+        // The table value is a maximum, rolled down and then scaled by how far the creature wound
+        // up. Both steps and the divisor are the ones WeaponBase.Attack() already uses for the
+        // player's swing, which goes through the same routine in the original.
+        // Rounded up where the original truncates, so that a blow that lands always costs at
+        // least a point: worth +1 either way, which is a third again on a rotworm and 3% on the
+        // last boss.
         damage = Utils.GetDamageRoll(damage);
-
-        // Comment from Hank's UW exporter.
-        // TODO: damage for NPCS is scaled based on a lookup table and a property in their mobile data.
-        // This is similar to the player attack charge. (values stored in segment_60 in UW2 exe)
-        // Lookup appears to be based on the value in the object at 0xF ( bits 12 to 15)
-        // For now just scale it randomly
-        if (damage > 2)
-        {
-            damage = (short)Random.Range(2, damage + 1);
-        }
+        damage = (damage * attackChargeScale[RollAttackCharge()] + 127) / 128;
 
         switch (result)
         {


### PR DESCRIPTION
Two placeholders in Critter sit right next to comments saying what is missing. The attack values read the first of the creature's three attacks, under "not sure how we determine which, if there are options"; the damage is then scaled by a random draw, under a TODO saying the original scales it from a lookup table indexed by four bits of the creature's mobile data, the way the player's attack charge works. This fills in both, from the game's own data and from the original executable, which I leaned on AI to disassemble.

Creatures now swing with the attack their data picks, and the blow is scaled by how long they wound up instead of by a random draw. Per swing that comes to about a fifth more damage than before, but the shape matters more than the total: which attack a creature uses, and how much a wound-up blow hurts. A mongbat, whose only attack is the second one, stops swinging with an empty attack.

Details
-------

THE THIRD BYTE OF EACH ATTACK IS A PROBABILITY

This part needs no disassembly, and anyone can check it. In the creature table each attack is three bytes at 0x13, 0x16 and 0x19 of the 48-byte row. Take the third byte of each of the three attacks and add them up: they come to exactly 100 on every row that has a triple at all - 60 of the 64, the other four being all zeroes. A goblin reads 40, 30, 30. A mongbat reads 0, 100, 0 - its only attack is the second one, which is why it has been hitting for the floor of 2.

The original picks with a plain weighted roll: take a random number from 0 to 99, walk the three attacks, and stop at the first whose probability is greater than what is left, subtracting as you go. ChooseAttack() is that loop, including its fall-through to the third attack.

The animation follows the same choice. Slots 1, 2 and 3 are bash, slash and thrust, one per row of the triple, so the slot is now the attack rather than a separate draw, falling back only when a creature has no frames for the one the data picked. That also removes an off-by-one in the old draw, which used Random.Range with an exclusive bound and so could never return the last available slot.

THE DAMAGE SCALE

The damage byte in the table is a maximum, not the damage dealt. The original rolls it down the way Utils.GetDamageRoll() already does here, and then multiplies by an entry from a sixteen entry table and divides by 128. Those are the same two steps, in the same order, with the same divisor, that WeaponBase.Attack() already applies to the player's swing - and in the original both go through one routine, which is why they match.

The table is at file offset 0x59390 in UW.EXE and 0x635e0 in UW2.EXE, sixteen 16-bit values, byte for byte identical in the two games:

    50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 155, 170, 185, 205, 230, 255

In a hex editor that reads 32 00 3C 00 46 00 50 00 5A 00 64 00 6E 00 78 00 82 00 8C 00 9B 00 AA 00 B9 00 CD 00 E6 00 FF 00. Divided by 128 it runs from 0.39 to 1.99. The fact that both games carry the same sixteen values in the same place is itself evidence that this is engine data rather than a coincidence of two byte patterns.

One deliberate difference: the original truncates that divide and this rounds it up, so a blow that lands always costs at least a point. It is worth +1 either way, which is a third again on a rotworm and 3% on the last boss. Truncating twice - once on the dice and once on the scale - takes the weakest creatures below where they are today and lets them land for nothing at all, which reads as a bug even though it is faithful.

This is not a new finding. The TODO in TryDamageTarget(), which came from Hank's exporter, already said the scale exists, that it is indexed by four bits of the creature's mobile data, and that it works like the player's attack charge. All three turned out to be right; what was missing was where the table is and what feeds the index.

THE INDEX IS A CHARGE THE CREATURE BUILDS BEFORE IT SWINGS

Described without the assembly: a creature that is in reach but has not yet committed to a blow spends each tick doing one of two things. One time in four it starts an attack - it runs the weighted roll above, writes the chosen attack into its own state, and the swing begins. The other three times it steps a counter, which saturates at fifteen. When the blow finally lands, the counter is read as the index into the table and then cleared, along with the chosen attack. During the swing itself the counter cannot grow, because the branch that steps it is not reached while an attack is in progress.

So the charge at the blow is simply the run of ticks before that one in four came up. That is a geometric draw with a mean of 3, which is what RollAttackCharge() does in six lines. A quarter of blows land uncharged at 0.39, and about one in a hundred lands at the top of the table.

THE INSTRUCTIONS

Offsets are into UW.EXE as it ships, so they go straight into a disassembler: objdump -D -b binary -m i8086 --start-address=0x19a09 UW.EXE

Picking the attack, 0x19a09. rand() % 100 is the ticket; the loop walks the probability byte of each attack, at 0x15, 0x18 and 0x1B of the row, and stops at the first one larger than what is left:

    19a1b  lcall rand ; mov $0x64,%bx ; cwtd ; idiv %bx ; mov %dx,%si
    19a28  movw $0x0,-0x4(%bp)              ; i = 0
    19a2f  mov -0x4(%bp),%ax ; mov $0x3,%dx ; imul %dx
           mov 0x2458,%bx ; add %ax,%bx     ; row + 3*i
    19a3d  mov 0x15(%bx),%al                ; prob[i]
    19a42  sub %ax,%si                      ; ticket -= prob[i]
    19a44  incw -0x4(%bp)
    19a5a  cmp %si,%ax ; jg  chosen         ; prob[i] > ticket ?
    19a5e  cmpw $0x2,-0x4(%bp) ; jl loop

and writes the choice into the creature's action code as i + 1:

    19a68  mov %es:0x15(%bx),%al ; and $0xc0,%al
    19a6e  mov -0x4(%bp),%dl ; inc %dl ; and $0x3f,%dl
    19a79  or %dl,%al ; mov %al,%es:0x15(%bx)

Building the charge, 0x19aa0, in the other branch of the same one-in-four. Top four bits of the word at 0x0F, stepped by one, stopped at fifteen:

    19aa0  mov %es:0xf(%bx),%ax ; and $0xf000,%ax ; shr $0xc,%ax
    19aaa  cmp $0xf,%ax ; jae done
    19ab6  mov %es:0xf(%bx),%dx ; and $0xf000,%dx ; shr $0xc,%dx
    19ac1  inc %dx ; and $0xf,%dx ; shl $0xc,%dx
    19ac9  or %dx,%ax ; mov %ax,%es:0xf(%bx)

The blow, 0x1b683. The swing's phase is the top four bits of the word at 0x0B; the creature update advances it by one a tick and resolves the blow on the tick it reads 4 - the jne is the branch that advances it instead:

    1b683  mov %es:0xb(%bx),%ax ; and $0xf000,%ax ; shr $0xc,%ax
    1b68d  cmp $0x4,%ax
    1b690  jne advance_phase

Reading the table, 0x1b6ab. The index is the charge, doubled because the entries are words, and 0x5619 is the segment the table lives in:

    1b6ab  mov %es:0xf(%bx),%bx ; and $0xf000,%bx ; shr $0xc,%bx
    1b6b6  shl $1,%bx
    1b6b8  mov $0x5619,%ax ; mov %ax,%es
    1b6bd  mov %es:0x0(%bx),%al

Rolling and scaling, 0x24cb5. The floor of 2, the dice and the divide by 128 are all here, in the routine that applies a resolved blow:

    24cd9  cmpw $0x2,0x2670 ; jge ... ; movw $0x2,0x2670
    24ce6  mov 0x2670,%ax ; mov $0x6,%bx ; idiv %bx    ; n / 6 and n % 6
    24d0c  lcall 0x35bd:0x11e                          ; (n/6)d6
    24d22  lcall 0x35bd:0x11e                          ; + 1d(n%6)
    24d2e  mov 0x2680,%al ; mov 0x2670,%ax
    24d38  imul %dx ; sar $0x7                         ; * scale / 128

The sar is the truncating divide this rounds up instead.

0x35bd:0x11e takes a count and a number of sides, seeds the result with the count and adds that many draws of rand() * sides / 32768 - that is, count dice of that many sides, which is what GetDamageRoll() builds.

0x2680 is the scale, and it is shared: the player's swing fills it at 0x25804 with MinCharge + (MaxCharge - MinCharge) * charge / 100 from the weapon's row before calling the same resolve at 0x2581c. Creatures fill it with the table entry above.

And 0x1b6df clears all of it once the blow is resolved: the action code loses its low six bits, the phase and the charge their top four.

WHAT IT CHANGES

Expected damage per blow that lands, with the three attacks weighted by their probabilities:

    creature          triple dmg/prob        was     now      x
    rotworm           3/100                 1.83    1.75   0.95
    goblin            6/40 4/30 5/30        2.67    2.40   0.90
    mongbat           0/0 6/100 0/0         1.50    2.69   1.79
    green lizardman   11/70 10/30           4.25    4.49   1.06
    troll             18/70 16/30           6.25    6.97   1.12
    great troll       22/50 20/50           7.50    8.44   1.12
    metal golem       25/50 25/50           8.50   10.00   1.18
    mage              15/50 25/50           5.50    8.10   1.47

Across every creature with a valid triple that total comes to 1.10x. Per swing rather than per blow that lands it comes to about 1.2x, because a creature that now uses a different attack also uses that attack's to-hit byte. It is not a uniform change, and that is worth saying plainly.

What rises is the creatures whose data points at a better attack than the first one. A mongbat gains twice over: the attack it now uses has a to-hit byte of 8 where the one it was using had 0, and over a play session its blows landed 26% of the time against 6% before. A mage reaches the 25 damage attack it rolls half the time.

The two weakest creatures come out slightly below where they were, because the roll and the scale both divide in integers. Rounding the scale up rather than down is what keeps that from turning into blows worth nothing.

HOW IT WAS CHECKED

I put a line of logging on the resolved swing, recording the chosen attack, the charge, the rolled value and the damage, and played a session of 180 swings against it.

Every one of the 54 blows that landed carried exactly the damage the formula gives for its logged roll and charge - 54 of 54, no discrepancies. The charge came out close to the geometric draw it should be, mean 3.28 against 3.00 expected, a fifth of blows at zero; it runs a little high because the counter is not cleared when a creature loses reach, only when it lands a blow, so it carries over between approaches.

The attack choice matched the data. A mongbat took its second attack on 47 swings out of 47, which is what a 0/100/0 triple should do, and its attack score rose from 14.4 to 22.3 - the second attack's to-hit byte is 8 where the first one's is 0. A great troll split 7 and 6 on its 50/50 triple. Criticals show up in the log as a doubled damage value before the roll, 44 for a 22 and 40 for a 20, which is where the original doubles it too.

On the same 54 blows, held to the same nominals and the same critical outcomes, the old two-draw code would have averaged 4.89 damage against the 6.19 these landed for, so 1.26x on this sample - a mix weighted towards mongbats and great trolls, where the change is largest. Rounding down instead of up would have given 5.19, and six of the 54 blows, 11%, would have landed for nothing.

The attack score is unchanged except for one bound. Where the original rolls it, it adds rand() % 6 + 7, which reaches 12; Random.Range(7, 12) stops at
11. That also confirms the rest of that line, including reading half of the equipment-damage byte as a to-hit bonus, which looks odd against the file format notes but is exactly what the original does.

WHAT IS LEFT OUT

The flanking bonus is real and is still a stub here. The original takes the difference between the two headings, folds it to 0 through 4, and adds it both to the attack score and to the damage, the latter after the scale - so striking a target that is facing away is worth up to 4 more on each. CalcFlankingBonus() returns 0, and its comment now says what the value should be and where it goes.

The original also gates two rolls behind a flag carried in the creature's placed data, set on 138 of the 872 creatures in the levels: the 7 to 12 on the attack score, and a further 4 to 15 on the damage. Neither the gate nor the damage roll is reproduced here; the attack score roll stays unconditional as it already was.

It also picks a body part for each blow and adjusts the attack score by it when the target is the player. That is not reproduced either.

Strength / 5 is left as it is. It contributes nothing, because that byte is zero for all 64 creatures, but the original reads the same byte and divides it the same way before the roll, so the term is faithful rather than dead.

Note: this was very difficult to verify, so I had to rely heavily on AI.