### PR TITLE
Combat: restore the original's armour and to-hit numbers

### DIFF
--- a/Assets/Game/Scripts/Armour.cs
+++ b/Assets/Game/Scripts/Armour.cs
@@ -61,6 +61,25 @@ public class Armour : UUObject
         return defence;
     }
 
+    /// <summary>
+    /// The worn value minus a Protection enchantment the player has not pinned down yet. The flat
+    /// point every piece gets and the table protection are visible on the item, so they always
+    /// count; the enchantment is not, and only a critical Lore result names it (see
+    /// <see cref="GetIdentifiedName"/>). Until then the panel shows the crown, not the crown of
+    /// protection - while the bonus goes on working.
+    /// </summary>
+    public override int GetKnownDefence()
+    {
+        int defence = GetDefence();
+        if (enchantmentType == EEnchantmentType.Protection
+            && loreResult != Skills.ESkillTestResult.CriticalSuccess)
+        {
+            defence -= 1 + enchantmentIndex;
+        }
+
+        return defence;
+    }
+
     public override int GetToughness()
     {
         int toughness = 0;

--- a/Assets/Game/Scripts/Critter.cs
+++ b/Assets/Game/Scripts/Critter.cs
@@ -20,6 +20,7 @@ public class CritterSaveData : UUObjectSaveData
     public int heading;
     public int hunger;
     public int whoami;
+    public bool elite;
     public int movementType;
     public int state;
     public float stateTime;
@@ -309,6 +310,12 @@ public class Critter : UUObject
     public int hunger;
     public EWhoAmI whoami;
 
+    // Bit 2 of critterData[6]: a marker the level designers put on 138 of the 872 placed creatures,
+    // and which nothing in UW.EXE ever sets or clears. One branch of the original (0x25a7b) gates
+    // two bonuses on it, +7..12 on the attack score and +4..15 on the damage; the other 84% get
+    // neither. It also multiplies the creature's own armour by 5/3 (0x24e03), which is not used yet.
+    public bool elite;
+
     public float walkSpeed = 1.0f;
     public float confusedSpeed = 2.0f;
     public float runSpeed = 3.0f;
@@ -356,6 +363,35 @@ public class Critter : UUObject
         return (v >> b0) & ((1 << (1 + b1 - b0)) - 1);
     }
 
+    /// <summary>
+    /// Bit 2 of critterData[6]. Nothing in UW.EXE ever sets or clears it, so it is level data:
+    /// 138 of the 872 placed creatures carry it (UW.EXE 0x25a7b).
+    /// </summary>
+    private static bool IsEliteInData(byte[] critterData)
+    {
+        return critterData != null && (critterData[6] & (1 << 2)) != 0;
+    }
+
+    /// <summary>
+    /// Reads the marker back from the level rather than trusting the save. It is static data, and
+    /// a save written before <see cref="elite"/> existed answers false for every creature already
+    /// on a level the player had visited - which would leave the marker dead for anyone carrying
+    /// on an old game. Creatures with no level of origin, summoned ones, keep what they were given.
+    /// </summary>
+    private void RefreshEliteFromLevel()
+    {
+        if (originalLevel <= 0 || objectIndex <= 0 || objectIndex >= 256 || LevelLoader.sLevelLoader == null)
+        {
+            return;
+        }
+
+        byte[] fromLevel = LevelLoader.sLevelLoader.ReadCritterDataFromLevel(originalLevel, objectIndex);
+        if (fromLevel != null)
+        {
+            elite = IsEliteInData(fromLevel);
+        }
+    }
+
     public override void Initialize(ushort[] objData, byte[] critterData)
     {
         base.Initialize(objData, critterData);
@@ -377,6 +413,7 @@ public class Critter : UUObject
             heading = critterData[16] & 31;
             hunger = critterData[17] & 127;
             whoami = (EWhoAmI)critterData[18];
+            elite = IsEliteInData(critterData);
 
             movementType = (EMovementType)(stats.Category & 0xf);
         }
@@ -3368,6 +3405,17 @@ public class Critter : UUObject
         return damage * Random.Range(1, 3);
     }
 
+    /// <summary>
+    /// The height the swing lands at: the middle of the creature's own body, which is what the
+    /// original compares against the target's extent to pick a body part (UW.EXE 0x2441a).
+    /// </summary>
+    private float GetSwingHeight()
+    {
+        return cachedCharacterController != null
+            ? transform.TransformPoint(cachedCharacterController.center).y
+            : transform.position.y;
+    }
+
     void TryDamageTarget()
     {
         if (GetDistanceToTarget() > meleeAttackRange + meleeAttackHysteresis)
@@ -3389,7 +3437,17 @@ public class Critter : UUObject
         // the equipment-damage byte plus a roll. The original's roll is rand() % 6 + 7, which
         // reaches 12; Random.Range stops one short of its bound.
         int flankingbonus = CalcFlankingBonus();
-        int attackScore = attackChanceToHit + (equipDamage / 2) + Random.Range(7, 13) + flankingbonus;
+        int attackScore = attackChanceToHit + (equipDamage / 2) + flankingbonus;
+        int damageBonus = 0;
+        if (elite)
+        {
+            // one branch in the original grants both of these, and only to the marked creatures
+            // (UW.EXE 0x25a7b). Giving the attack roll to everyone made the other 84% sharper than
+            // they ever were, which is what kept a lightly armoured player honest and hid the fact
+            // that a heavily armoured one could not be touched at all.
+            attackScore += Random.Range(7, 13);
+            damageBonus = Random.Range(4, 16);
+        }
 
         int defenceScore = attackTarget == null ? PlayerObject.Player.GetDefence() : attackTarget.GetDefence();
 
@@ -3399,7 +3457,7 @@ public class Critter : UUObject
             result = Skills.ESkillTestResult.Success;
         }
 
-        int damage = Mathf.Max(2, attackDamage + strength / 5);
+        int damage = Mathf.Max(2, attackDamage + strength / 5 + damageBonus);
         if (result == Skills.ESkillTestResult.CriticalSuccess)
         {
             damage = GetCriticalDamage(damage);
@@ -3437,6 +3495,7 @@ public class Critter : UUObject
                         poisoning = true;
                     }
                 }
+                damage = PlayerObject.Player.AbsorbWithArmour(damage, GetSwingHeight());
                 PlayerObject.Player.Damage(result, damage, poisoning ? EDamageType.Poison : EDamageType.Damage);
             }
             else
@@ -3994,6 +4053,7 @@ public class Critter : UUObject
             critterData.heading = heading;
             critterData.hunger = hunger;
             critterData.whoami = (int)whoami;
+            critterData.elite = elite;
             critterData.movementType = (int)movementType;
             critterData.state = (int)state;
             critterData.stateTime = stateTime;
@@ -4079,6 +4139,8 @@ public class Critter : UUObject
             heading = critterData.heading;
             hunger = critterData.hunger;
             whoami = (EWhoAmI)critterData.whoami;
+            elite = critterData.elite;
+            RefreshEliteFromLevel();
             movementType = (EMovementType)critterData.movementType;
             state = (EState)critterData.state;
             stateTime = critterData.stateTime;

--- a/Assets/Game/Scripts/Inventory.cs
+++ b/Assets/Game/Scripts/Inventory.cs
@@ -18,6 +18,18 @@ public enum EInvSlot
     None
 }
 
+/// <summary>
+/// The four body parts the original splits armour across, in its own order. A melee hit picks one
+/// and the protection covering it is subtracted from the damage (UW.EXE 0x24dc1).
+/// </summary>
+public enum EBodyPart
+{
+    Torso,
+    Arms,
+    Legs,
+    Head
+}
+
 public class Inventory : MonoBehaviour
 {
     public Texture cursor;
@@ -40,6 +52,11 @@ public class Inventory : MonoBehaviour
 
     // the style for the carry weight number
     public GUIStyle carryStyle;
+
+    // carryStyle is centred. The two ratings are drawn flush to their own side instead, the
+    // defence against the left edge of the shield slot and the armour against the right.
+    private GUIStyle ratingLeftStyle;
+    private GUIStyle ratingRightStyle;
 
     // the style for the item labels
     public GUIStyle descriptionStyle;
@@ -4331,20 +4348,67 @@ public class Inventory : MonoBehaviour
         EInvSlot.RightHand
     };
 
-    public int GetTotalArmourScore()
+    /// <summary>
+    /// The armour total as the player knows it, for the panel. Pieces answer with
+    /// <see cref="UUObject.GetKnownDefence"/>, so an enchantment he has not identified is missing
+    /// from the figure even though it is working: the number must not do the Lore roll's job.
+    /// Combat reads <see cref="GetArmourByBodyPart"/> instead, which uses the true values.
+    /// </summary>
+    public int GetKnownArmourScore()
     {
         int score = 0;
         foreach (var armorSlot in armorSlots)
         {
-            // TODO: add GetDefence to rings
+            // Not the fingers: the original's loop covers the five armour slots and the shield
+            // hand only (UW.EXE 0x7e466 and 0x7e4ab), and every ring reads zero protection anyway.
             UUObject armour = invSlotContents[(int)armorSlot];
             if (armour != null)
             {
-                score += armour.GetDefence();
+                score += armour.GetKnownDefence();
             }
         }
 
         return score;
+    }
+
+    // Which body part each worn piece covers. The original keeps it as the table 03 00 01 02 02 at
+    // DS:0x1af8 in UW.EXE, indexed by these five slots in this order; the shield hand covers torso
+    // and arms both (UW.EXE 0x7e512).
+    private static readonly EInvSlot[] armourPieceSlots =
+    {
+        EInvSlot.Head, EInvSlot.Torso, EInvSlot.Hands, EInvSlot.Legs, EInvSlot.Feet
+    };
+
+    private static readonly EBodyPart[] armourPieceParts =
+    {
+        EBodyPart.Head, EBodyPart.Torso, EBodyPart.Arms, EBodyPart.Legs, EBodyPart.Legs
+    };
+
+    /// <summary>
+    /// Protection per body part, the way the original keeps it: the pieces covering a part are
+    /// summed and the total is subtracted from the damage of a hit that lands there.
+    /// </summary>
+    public int[] GetArmourByBodyPart()
+    {
+        int[] armour = new int[4];
+        for (int i = 0; i < armourPieceSlots.Length; ++i)
+        {
+            UUObject piece = invSlotContents[(int)armourPieceSlots[i]];
+            if (piece != null)
+            {
+                armour[(int)armourPieceParts[i]] += piece.GetDefence();
+            }
+        }
+
+        UUObject shield = invSlotContents[(int)(PlayerData.sData.leftHanded ? EInvSlot.RightHand : EInvSlot.LeftHand)];
+        if (shield != null)
+        {
+            // a weapon in that hand answers 0, so this only counts shields
+            armour[(int)EBodyPart.Torso] += shield.GetDefence();
+            armour[(int)EBodyPart.Arms] += shield.GetDefence();
+        }
+
+        return armour;
     }
 
     public UUObject GetRandomArmourPiece()
@@ -5004,11 +5068,33 @@ public class Inventory : MonoBehaviour
 
             // attack and defence ratings
             {
-                int defence = PlayerObject.Player.GetDefence();
+                // Two numbers, because once armour is off the to-hit roll the panel is showing two
+                // different things and one figure cannot honestly be both. On the left what keeps a
+                // blow from landing - the Defense skill, half the skill of the weapon in hand and
+                // magical protection, which is the side the original puts magic on too. On the
+                // right what keeps a blow that lands from hurting: the armour worn. Together they
+                // are the single number this used to show.
+                if (ratingLeftStyle == null && carryStyle != null)
+                {
+                    ratingLeftStyle = new GUIStyle(carryStyle) { alignment = TextAnchor.LowerLeft };
+                    ratingRightStyle = new GUIStyle(carryStyle) { alignment = TextAnchor.LowerRight };
+                }
+
                 EInvSlot shieldHandSlot = PlayerData.sData.leftHanded ? EInvSlot.RightHand : EInvSlot.LeftHand;
                 float x = Screen.width - invPosition + 3 * invSlots[(int)shieldHandSlot].cx;
                 float y = 30 + 3.6f * invSlots[(int)shieldHandSlot].cy;
-                GUI.Label(new Rect(x, y + 40, 20, 20), defence.ToString(), carryStyle);
+
+                // Two boxes, each flush to its own side of the shield slot: the defence against the
+                // left edge, the armour against the right, so the pair reads as two figures rather
+                // than one. Nudge the offsets below to move them; a digit is about twelve pixels
+                // wide at this font size.
+                const float digit = 12.0f;
+                float defenceBox = x;                       // left edge of the defence, flush left
+                float armourBox = x + 23;                   // the armour box, its text flush right
+                GUI.Label(new Rect(defenceBox, y + 40, 2 * digit, 20),
+                    PlayerObject.Player.GetDefence().ToString(), ratingLeftStyle ?? carryStyle);
+                GUI.Label(new Rect(armourBox, y + 40, 2 * digit + 2, 20),
+                    GetKnownArmourScore().ToString(), ratingRightStyle ?? carryStyle);
             }
             {
                 int attack = 0;

--- a/Assets/Game/Scripts/ObjectsData.cs
+++ b/Assets/Game/Scripts/ObjectsData.cs
@@ -75,8 +75,12 @@ public class ObjectsData
     public class CritterData
     {
         /*
-00h 	1 	uint8 	Level: 	Level of the creature.
-01h 	3 	 ?? 	 ?? 	 ??
+00h 	4 	uint8[4] 	Armour: 	Protection per body part, in the order torso, arms, legs, head.
+Subtracted from the damage of a hit that lands on that part (UW.EXE 0x24dc1). 255 in bytes 1-3
+means the creature has no distinct limbs and the original falls back to byte 0 (UW.EXE 0x24dcc):
+humanoids carry four values (goblin 3 2 2 2, fighter 5 4 4 4, metal golem 7 7 7 7), worms and
+bats carry "n 255 255 255". The player has an entry of his own in this table and the game fills
+these four bytes from the armour he wears (UW.EXE 0x7e444).
 04h 	1 	uint8 	HitPoints 	Average hit points. <is this meant to be uint8
 05h     1    uint8 Strength  - for the player these values are copied at save load into the table.
 06h 	1 	uint8 	Dexterity
@@ -92,7 +96,9 @@ Mask 0xF0 is the remains; Nothing = 0x00, RotwormCorpse = 0x20, Rubble = 0x40, W
 0Fh 	1 	uint8 	PoisonDamage 	Amount of poison damage this is capable of on attack.
 10h 	1 	uint8 	Category 	Ethereal = 0x00 (Ethereal critters like ghosts, wisps, and shadow beasts), Humanoid = 0x01 (Humanlike non-thinking forms like lizardmen, trolls, ghouls, and mages), Flying = 0x02 (Flying critters like bats and imps), Swimming = 0x03 (Swimming critters like lurkers), Creeping = 0x04 (Creeping critters like rats and spiders), Crawling = 0x05 (Crawling critters like slugs, worms, reapers (!), and fire elementals (!!)), EarthGolem = 0x11 (Only used for the earth golem), Human = 0x51 (Humanlike thinking forms like goblins, skeletons, mountainmen, fighters, outcasts, and stone and metal golems).
 11h 	1 	uint8 	EquipmentDamage 	Amount of equipment damage this is capable of on attack.
-12h 	1 	 ?? 	 ?? 	 ??
+12h 	1 	uint8 	Defence: 	What an attack roll is made against (UW.EXE 0x24b96). For the
+player the game writes his Defense skill plus half the skill of the weapon in his hand into
+this byte of his own row (UW.EXE 0x7e535 and 0x7e5f8); armour is not part of it.
 13h 	9 	Probability[3] 	Probabilities 	Each has the form (uint16 value, uint8 percent). What this means is unknown.
 1Ch 	12 	 ?? 	 ?? 	 ??
 28h 	2 	uint16 	Experience: 	Experience provided when killed.
@@ -100,10 +106,7 @@ Mask 0xF0 is the remains; Nothing = 0x00, RotwormCorpse = 0x20, Rubble = 0x40, W
 2Dh     Some sort of value (magic users related)
 2Fh 	1 	uint8 	 ?? 	Always 73.
 */
-        public int Level;
-        public byte unk01;
-        public byte unk02;
-        public byte unk03;
+        public int[] Armour; // per body part, see EBodyPart
         public short AvgHit;//Is this defence?????
         public int Strength;
         public int Dexterity;
@@ -204,10 +207,11 @@ Mask 0xF0 is the remains; Nothing = 0x00, RotwormCorpse = 0x20, Rubble = 0x40, W
         for (int i = 0; i < critterStats.Length; ++i)
         {
             critterStats[i] = new CritterData();
-            critterStats[i].Level = stream.GetByte();
-            critterStats[i].unk01 = stream.GetByte();
-            critterStats[i].unk02 = stream.GetByte();
-            critterStats[i].unk03 = stream.GetByte();
+            critterStats[i].Armour = new int[4];
+            for (int j = 0; j < 4; ++j)
+            {
+                critterStats[i].Armour[j] = stream.GetByte();
+            }
             critterStats[i].AvgHit = stream.GetByte();//Average Hitpoints - changed from uint16 to uint8
 
             critterStats[i].Strength = stream.GetByte(); //Base damage calculations

--- a/Assets/Game/Scripts/PlayerObject.cs
+++ b/Assets/Game/Scripts/PlayerObject.cs
@@ -142,9 +142,16 @@ public class PlayerObject : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// What a monster's attack roll is made against. Armour is deliberately not part of it: the
+    /// original keeps this number as the Defense skill plus half the skill of the weapon in hand
+    /// (UW.EXE 0x7e535 and 0x7e5f8) and spends armour on the damage instead, in
+    /// <see cref="AbsorbWithArmour"/>. Adding armour here made a plate-armoured player untouchable
+    /// rather than merely hard to hurt.
+    /// </summary>
     public int GetDefence()
     {
-        int defenceScore = Skills.GetSkill(ESkill.Defense) + Inventory.sInv.GetTotalArmourScore();
+        int defenceScore = Skills.GetSkill(ESkill.Defense);
         defenceScore += Magic.sMagic.GetSpellArmourScore();
         Weapon weapon = Inventory.sInv.invSlotContents[(int)(PlayerData.sData.leftHanded ? EInvSlot.LeftHand : EInvSlot.RightHand)] as Weapon;
         defenceScore += Skills.GetSkill(weapon != null ? weapon.skill : ESkill.Unarmed) / 2;
@@ -155,6 +162,62 @@ public class PlayerObject : MonoBehaviour
         }
 
         return defenceScore;
+    }
+
+    /// <summary>
+    /// Takes the protection covering the body part a blow arriving at <paramref name="strikeHeight"/>
+    /// lands on off the damage, floored at zero (UW.EXE 0x24e14). This is what armour does in the
+    /// original: it does not stop blows from landing, it stops them from hurting. Every blow that
+    /// reaches the damage routine goes through it, a swing and an arrow alike, because melee and
+    /// missiles share that routine (UW.EXE 0x2527e and 0x259e7).
+    /// </summary>
+    public int AbsorbWithArmour(int damage, float strikeHeight)
+    {
+        return Math.Max(0, damage - Inventory.sInv.GetArmourByBodyPart()[(int)PickBodyPart(strikeHeight)]);
+    }
+
+    /// <summary>
+    /// Which body part a blow arriving at <paramref name="strikeHeight"/> lands on. The original
+    /// compares that height with the vertical extent of what it is hitting (UW.EXE 0x2441a): under
+    /// the feet is legs, over the head is head, and in between the split leans low or high
+    /// depending on which of the two is taller. So a rotworm goes for the legs and an imp for the
+    /// head, and the armour that answers is the one covering that part.
+    /// </summary>
+    public EBodyPart PickBodyPart(float strikeHeight)
+    {
+        CharacterController body = cachedCharacterController;
+        if (body == null)
+        {
+            return EBodyPart.Torso;
+        }
+
+        float middle = transform.TransformPoint(body.center).y;
+        float foot = middle - 0.5f * body.height;
+        float head = middle + 0.5f * body.height;
+
+        if (strikeHeight < foot)
+        {
+            return EBodyPart.Legs;
+        }
+
+        if (strikeHeight > head)
+        {
+            return EBodyPart.Head;
+        }
+
+        if (strikeHeight < middle)
+        {
+            if (Random.Range(0, 2) == 0)
+            {
+                return EBodyPart.Legs;
+            }
+        }
+        else if (Random.Range(0, 3) == 0)
+        {
+            return EBodyPart.Head;
+        }
+
+        return Random.Range(0, 3) == 0 ? EBodyPart.Arms : EBodyPart.Torso;
     }
 
     public static void LoadSkills()

--- a/Assets/Game/Scripts/Projectile.cs
+++ b/Assets/Game/Scripts/Projectile.cs
@@ -174,6 +174,10 @@ public class Projectile : UUObject
                             damage = 0;
                         }
 
+                        // Missiles and melee share the damage routine in the original (UW.EXE
+                        // 0x259e7 and 0x2527e), so armour soaks an arrow exactly as it soaks a
+                        // swing, by the protection covering wherever it struck.
+                        damage = player.AbsorbWithArmour(damage, transform.position.y);
                         if (damage > 0)
                         {
                             player.Damage(Skills.ESkillTestResult.Success, damage, EDamageType.Damage);

--- a/Assets/Game/Scripts/UUObject.cs
+++ b/Assets/Game/Scripts/UUObject.cs
@@ -1110,6 +1110,16 @@ public class UUObject : LevelObject
         return 0;
     }
 
+    /// <summary>
+    /// What the player is entitled to see of this item's protection. The same as
+    /// <see cref="GetDefence"/> unless the piece carries an enchantment he has not identified: that
+    /// still protects him in combat, it just must not announce itself through a number in the panel.
+    /// </summary>
+    public virtual int GetKnownDefence()
+    {
+        return GetDefence();
+    }
+
     public virtual int GetToughness()
     {
         return 0;

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Attempts to be gameplay-accurate while adding some modern conveniences
   - some tidied-up portraits
   - achievements
   - gamepad support
+  - three ratings added to the inventory panel: attack by the weapon hand, defence and armour by the shield hand
 


### PR DESCRIPTION
This is a large change and a necessary one. Worn armour is added to the score a monster's attack roll has to beat, and six pieces are worth up to 31 points against a roll whose whole range is 30. In chain the player is nearly untouchable; in plate he is untouchable. Logged on the current build, in chain: 95 swings from trolls and great trolls landed 13 times, and a mixed session of 41 swings landed once. In plate, across every placed creature of the nine levels, 0.2%, and trolls, fighters and mages reach zero.

The original never puts armour there. It keeps that score as the Defense skill plus half the skill of the weapon in hand, and spends armour on the damage instead, subtracting the protection covering the body part that was struck. This moves it back, both halves. It is a restoration rather than a balance choice, and every step below is read off UW.EXE rather than guessed.

Details
-------

Where the two numbers live. The player is object 1 of the master object list and has a row of his own in the 64x48 critter table; the game keeps that row as live state and saves it with the game. Byte 0x12 of the row is what an attack roll is made against, and the only two instructions that write it are 0x7e535, the Defense skill, and 0x7e5f8, half the skill of the weapon in hand. That was checked exhaustively: the only ways to hold a pointer into the table are the literal 0x4a52 and the variables derived from it, the literal appears twenty times, and reading each of those functions end to end turns up no third writer. Bytes 0 to 3 of the same row are the armour, one per body part, filled at 0x7e444 from the pieces worn with 1 + protection * quality / 64 - the formula Armour.GetDefence() already had. The damage routine subtracts them at 0x24dc1 and floors the result at zero.

Body parts. The slot to part table is 03 00 01 02 02 at DS:0x1af8, for head, torso, hands, legs and feet in that order, and a shield covers torso and arms both. Which part a blow lands on comes from the geometry at 0x2441a: the height of the blow against the vertical extent of the target, so a rotworm goes for the legs and something that hovers goes for the head, with a weighted draw in between. It reads that off the character controllers.

Arrows too. Melee and missiles converge on the same damage routine in the original - 0x2527e for a swing, 0x259e7 for a missile, both into 0x24cb5 - so the subtraction is on both paths here as well, with the projectile's own impact height standing in for the swing height.

The attack roll bonus. The +7..12 that every creature was getting is inside a test in the original, at 0x25a7b, on bit 2 of critterData[6]. Nothing in the executable ever sets or clears that bit, so it is level data: 138 of the 872 placed creatures carry it, 16%, spread over 37 types. Proving that took the same exhaustive treatment - every encoding that could write the word at 0x0D or the byte at 0x0E, segment prefixes included, filtered down to the instructions actually reachable inside their own function. The same branch also grants +4..15 on the damage, which had no counterpart here; it is one branch, and porting half of it would have been arbitrary, so both are in.

The bonus is read back from LEV.ARK rather than trusted to the save, by the object index and level of origin the save already keeps. Serialising it alone would have left it dead for anyone carrying on an old game, because a save written before the field existed answers false for every creature on a level already visited. That one was found the hard way: 748 logged swings against goblins and mountainmen, the two types most often marked, produced not one marked creature until it was fixed.

What it does to the numbers. Simulated over every placed creature of the nine levels, weighted by how many there are, boss excluded because it hits regardless. Same character throughout, only the armour changes:

    armour     hits landed        damage per swing
               before  after      before  after
    none        39.7%  20.1%        2.25   1.45
    leather     17.7%  20.1%        1.13   1.07
    mail         4.0%  20.1%        0.27   0.56
    plate        0.5%  20.1%        0.04   0.32

The share of blows that land no longer moves with the armour, which is the point: armour stops blows from hurting, not from landing. An unarmoured player comes out safer than before, because the attack roll he was never meant to face is gone; an armoured one is in a fight again. The two errors were cancelling each other out around leather, which is why this only showed once the player had a decent set.

Checked against play rather than only simulated, on 789 logged swings across five sessions, with the roll and the defence split written to the log so the same swings could be replayed against the new numbers. In chain, against trolls and great trolls, blows landing goes from 14% to 52% while damage per swing only moves from 1.24 to 1.51 - three times the hits, each worth about half, which is the shape intended. A marked creature comes out fifteen times more dangerous than an identical unmarked one.

The panel. The figure under the shield hand was the Defense skill plus the armour plus magic plus half the weapon skill, all in one. Those are now two mechanics - what keeps a blow from landing and what keeps it from hurting - so it reads as two, "20 / 21". Magic stays on the left, which is where the original keeps it as well: it is subtracted from the attacker's score at 0x24b8f, not from the damage. Neither figure has a counterpart in the original, which shows no ratings at all; the split just stops one number from standing for two things. Both are drawn right aligned in fixed boxes with the slash in its own, so no digit slides when a value crosses ten.

The right hand figure shows what the player knows rather than what he has. A Protection enchantment is worth 1 to 8 points and the item does not say so until a critical Lore result names it, so until then the panel would be doing the Lore roll's job. Pieces answer it through GetKnownDefence(), which drops an unidentified enchantment, while combat reads the true value. The bonus works either way; only the display waits. Everything visible on the item counts from the start, including the flat point every worn piece collects even when the table gives it no protection - that is what the original does at 0x7e43d, so a crown is still worth its point.

Rings are not in that sum, and the standing TODO about adding them is wrong: the original's loop covers the five armour slots and the shield hand only (0x7e466 and 0x7e4ab), never the fingers. The comment now says so.

Left out on purpose. Monsters carry the same four armour bytes and the same routine applies them, so the player's blows should be soaked too - that is a separate change, it makes the player weaker, and it is not smuggled in here. Magic protection stays in the to-hit score, which is where the original puts it as well; only its size looks inflated, and that was not checked instruction by instruction. Traps, falls, poison and spell effects are untouched: whether the original routes those through the same routine was not established either way.