### PR TITLE
gitattributes: stop the catch-all cancelling the binary rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,21 @@
+# --- DEFAULTS ---
+* text=auto
+
 # --- UNITY TEXT FILES ---
 # Force LF to prevent the "Modified" ghosting you're seeing
-*.meta   text eol=lf
-*.unity  text eol=lf
-*.prefab text eol=lf
-*.asset  text eol=lf
-*.mat    text eol=lf
-*.controller text eol=lf
-*.overrideController text eol=lf
-*.anim   text eol=lf
+*.meta   text=auto eol=lf
+*.unity  text=auto eol=lf
+*.prefab text=auto eol=lf
+*.asset  text=auto eol=lf
+*.mat    text=auto eol=lf
+*.controller text=auto eol=lf
+*.overrideController text=auto eol=lf
+*.anim   text=auto eol=lf
 # --- CODE ---
-*.cs     text diff=csharp eol=lf
-*.shader text eol=lf
-*.cginc  text eol=lf
-*.hlsl   text eol=lf
+*.cs     text=auto diff=csharp eol=lf
+*.shader text=auto eol=lf
+*.cginc  text=auto eol=lf
+*.hlsl   text=auto eol=lf
 # --- BINARY ASSETS ---
 *.png    binary
 *.jpg    binary
@@ -22,5 +25,3 @@
 *.blend  binary
 *.wav    binary
 *.mp3    binary
-# --- DEFAULTS ---
-* text=auto


### PR DESCRIPTION
The final line, `* text=auto`, matches every path, and in .gitattributes a later line overrides an earlier one for the same attribute. So the `-text` on `*.tga` and the text half of `binary` on `*.png`, `*.jpg`, `*.psd`, `*.fbx`, `*.blend`, `*.wav` and `*.mp3` never take effect: `git check-attr text` reports `auto` for every one of them.

Moving the default above the other rules fixes that. The `text` on the Unity and code rules becomes `text=auto` in the same move, so that those paths keep exactly the attributes they have today - see below for why that half matters.

Nothing in the repository is corrupted today, so this is a safety net being put back rather than a fix for a visible symptom.

Details
-------

Measured over all 8195 tracked paths: the attributes change on 2131 of them, all with a binary extension, and only the `text` attribute moves, from `auto` to unset. No path with a text extension changes at all.

Why nothing is broken right now: `text=auto` does not mean "treat as text", it means "decide from the content", and git skips the conversion when it finds a NUL byte in the first 8000. Of the 2131 files with a binary extension, the number without an early NUL is zero, so the heuristic currently covers all of them.

The exception is the one line that already had `-text`. Under LFS the blob git stores for a .tga is not the image, it is the three-line ASCII pointer, which has no NUL at all, so the heuristic cannot help there. On checkout the text conversion runs before the smudge filter, so with `core.autocrlf=true` the pointer can reach git-lfs with CRLF endings. That is why git-lfs recommends `-text` alongside the lfs attributes, and there are 337 .tga files here.

Why `text` becomes `text=auto` on the Unity and code rules: reordering alone would promote those paths from auto-detection to unconditional text, and two tracked files with a text extension are actually binary - LightingData.asset under Assets/Lil Pupinduy, and
ProjectSettings/NetworkManager.asset. Neither contains a CRLF pair today, so neither would be harmed right now, but Unity writes LightingData.asset for any baked scene and can serialise scenes and prefabs in binary too. Auto-detection already excludes those files, and `eol=lf` still applies to everything it detects as text, so the "force LF" intent of those rules is unchanged.

No renormalisation follows from this, and that was measured rather than assumed. Every one of the 2131 affected files was run through `git hash-object` under both versions of this file, LFS filters included: all 2131 hashes come out identical, and every one of them already matches the blob stored in HEAD. `git status` is clean on the branch.

For files that do not exist yet the guarantee is structural rather than statistical: `-text` never converts, `text=auto` converts only when the content looks like text, so this can remove a conversion but never add one. A file whose content git reads correctly is handled the same way either side of this change; one that git would misread is the reason the change is worth making.