### PR TITLE
Skills: the skill roll was one value short compared to the original

### DIFF
--- a/Assets/Game/Scripts/Skills.cs
+++ b/Assets/Game/Scripts/Skills.cs
@@ -36,7 +36,12 @@ public class Skills
 
     public static ESkillTestResult GetResult(int hitChance, int target)
     {
-        int roll = hitChance + Random.Range(0, 30) - target;
+        // The original draws rand() % 31, so 0 to 30 inclusive - thirty-one values, not
+        // thirty. Random.Range with an int upper bound is exclusive, so it needs 31 to match.
+        // UW.EXE 0x3419c, read whole: mov $0x1f,%bx; cwtd; idiv %bx; add %dx,%si. rand() is
+        // 0xec5:0x0de7, file 0x12c37, and returns 0 to 32767, so the remainder spans the
+        // full 0 to 30. The four thresholds below already match the original exactly.
+        int roll = hitChance + Random.Range(0, 31) - target;
 
         if (roll <= 2)
         {


### PR DESCRIPTION
GetResult() drew Random.Range(0, 30), which is 0 to 29. The original draws rand() % 31, which is 0 to 30 - thirty-one values, not thirty. Every skill check in the game was very slightly harder than it should have been, and where the difficulty sat exactly one point above the skill the missing value was the whole of it: a critical success could not come up at all there, and now it can, one time in thirty-one.

Details
-------

UW.EXE 0x3419c, read from its prologue to its lret:

  si = skill - difficulty
  rand()
  mov $0x1f,%bx ; cwtd ; idiv %bx ; add %dx,%si     ; si += rand % 31
  si > 28 -> 2   si > 15 -> 1   si > 2 -> 0   else -1

rand() is 0xec5:0x0de7, file 0x12c37: a linear congruential generator with the constant 0x015a4e35 returning (seed >> 16) & 0x7fff, so 0 to 32767. The remainder therefore spans the full 0 to 30.

The four thresholds already matched the original exactly, so the range was the only thing wrong. Random.Range with an int upper bound is exclusive, hence 31.

The effect is small and uniform: one point of the range restored, which moves the chance of clearing a threshold by about three percentage points at the margin. It applies to all sixteen call sites, from the attack roll to picking a lock.

Exercised in a build with GetResult() forced to return 30 - the value the old range could never produce - and logging which line asked for it. All sixteen call sites were reached, with no exception and no error anywhere in the session, checked against two independent logs.

This is unlikely to be the only draw whose range does not match. It came to light only because the function was read from its prologue to its lret, and the other rolls have not had that treatment: the remake draws from Random.* in around two hundred places, while the original calls rand() at 153 sites across 62 functions, and the two sets have been paired up for only a handful so far. Working through the rest is a job of its own and belongs in its own change, not in this one.