### PR TITLE
Shrine: no half-attribute bonus on Strength skills, real mana cap

### DIFF
--- a/Assets/Game/Scripts/CreateCharacter.cs
+++ b/Assets/Game/Scripts/CreateCharacter.cs
@@ -454,7 +454,7 @@ public class CreateCharacter : MonoBehaviour
             fadeAlpha += Time.deltaTime;
             if (fadeAlpha > 1.0f)
             {
-                Skills.ManaAdvanced();
+                Skills.ManaAdvanced(refill: true);
                 
                 // Save character sex to PlayerPrefs for frontend background display
                 PlayerPrefs.SetString("LastCharacterSex", PlayerData.sData.female ? "female" : "male");

--- a/Assets/Game/Scripts/Skills.cs
+++ b/Assets/Game/Scripts/Skills.cs
@@ -69,6 +69,12 @@ public class Skills
         return PlayerData.sData.dexterity;
     }
 
+    /// <summary>True for the seven skills the original governs with Strength (Attack..Missile).</summary>
+    private static bool IsStrengthSkill(ESkill skill)
+    {
+        return (int)skill < 7;
+    }
+
     private static int GetRandomRange(ESkill skill)
     {
         int i = (int)skill;
@@ -77,13 +83,21 @@ public class Skills
         return 40; // dexterity
     }
 
-    public static void ManaAdvanced()
+    /// <summary>
+    /// Recomputes the mana ceiling from the Mana skill and Intelligence, and optionally refills the
+    /// pool. The original computes (Mana + 1) * Intelligence / 8 and refills only when its caller
+    /// asks: character creation passes 1, the shrine passes 0 (UW.EXE 0x81305, called from 0x6ca4c
+    /// and 0x819ab).
+    /// </summary>
+    public static void ManaAdvanced(bool refill)
     {
-        // https://wiki.ultimacodex.com/wiki/Character_attributes#Ultima_Underworld_and_Ultima_Underworld_II
         int manaSkill = PlayerData.sData.skill[(int)ESkill.Mana];
         int intellect = PlayerData.sData.intellect;
-        PlayerData.sData.maxMana = ((3 * manaSkill + 2) * intellect + 12) / 24;
-        PlayerData.sData.mana = PlayerData.sData.maxMana;
+        PlayerData.sData.maxMana = (manaSkill + 1) * intellect / 8;
+        if (refill)
+        {
+            PlayerData.sData.mana = PlayerData.sData.maxMana;
+        }
     }
     
     public static bool AdvanceSkill(ESkill skill)
@@ -93,7 +107,10 @@ public class Skills
         if (curVal < 2 * attrib && curVal < 30)
         {
             ++curVal;
-            if (curVal < attrib / 2)
+            // The original grants this second point only when the governing attribute is not
+            // Strength: the test is on the attribute index and skips it when that index is 0, so
+            // the seven Strength skills (Attack..Missile) never get it (UW.EXE 0x8155a).
+            if (!IsStrengthSkill(skill) && curVal < attrib / 2)
             {
                 ++curVal;
             }
@@ -109,7 +126,8 @@ public class Skills
             switch (skill)
             {
             case ESkill.Mana:
-                ManaAdvanced();
+                // Advancing Mana raises the ceiling; the original does not refill the pool here.
+                ManaAdvanced(refill: false);
                 break;
             }
             


### PR DESCRIPTION
Two numbers in Skills.cs came from a wiki page instead of the game, and one of them was attributed to the wrong routine.

A mantra advances a skill by up to three points: one always, one more when the skill is below half its governing attribute, and one more on a roll. The original grants that second point only when the governing attribute is not Strength, so the seven Strength skills - Attack, Defense, Unarmed, Sword, Axe, Mace, Missile - never get it. Ours gave it to everything, which made combat skills one point per mantra cheaper.

The mana ceiling is (Mana + 1) * Intelligence / 8, not ((3 * Mana + 2) * Intelligence + 12) / 24. The two disagree by one in 350 of the 930 combinations of Mana 0-30 and Intelligence 1-30, and ours was almost always the lower one. And the pool was refilled every time Mana advanced: the original refills only at character creation.

Details
-------

Read from UW.EXE, where the addresses below are byte offsets into the GOG build, in the form CONTRIBUTING.md describes. The shrine's advancement is 0x814e1, whose three calls all come from 0x816fd, the shrine itself; the four terms of the other routine at 0x8141f belong to character creation, which is a different rule with a different counterpart in CreateCharacter.IncreaseSkill(). The gate is unchanged and was already faithful - skill < 2 * attribute and skill < 30 - and so are the three random ranges 25 / 40 / 10, which the original keeps in three bytes at DS:0x1c8c and we already had right.

The derived stats live in 0x81305: it computes the mana ceiling and is called with 1 from character creation (0x6ca4c) and with 0 from the shrine (0x819ab), which is where the refill difference comes from. ManaAdvanced() now takes that flag explicitly at both call sites.

Checked in game: a mage rolled with Strength 12, advancing one of the Strength skills that class cannot be given at creation, so it started at zero, where the half-attribute point would certainly have applied before. The skill no longer gains it, a Dexterity skill in the same session still does, and the Mana mantra no longer refills the pool.