### PR TITLE
Projectile: remove the character-level damage bonus

### DIFF
--- a/Assets/Game/Scripts/Projectile.cs
+++ b/Assets/Game/Scripts/Projectile.cs
@@ -210,7 +210,10 @@ public class Projectile : UUObject
 
     private int GetDamageSkillBoost()
     {
-        int damage = PlayerData.sData.charLevel / 4;
+        // The original adds nothing per character level, here or in melee: the chain that
+        // works out a projectile's damage - UW.EXE 0x2b2bd, 0x258cf and 0x24cb5, each read
+        // whole - never reads the level, the byte at P1[0x3d].
+        int damage = 0;
         switch (type)
         {
         case EObjectType.MagicMissile:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- A projectile the player fires no longer does extra damage for the character's level, which the original adds neither to missiles nor to melee. It was a quarter of the level, so at level 13 a sling stone hit for five where the stone itself is worth two.
+
 - Mantras at a shrine no longer hand out an extra point on the seven skills governed by Strength, the way the original withholds it there and nowhere else. The mana ceiling now uses the game's own formula rather than one from a wiki, and saying the mana mantra no longer tops the pool back up.
 
 - Every skill roll drew from a range one value short of the original's, so every check in the game - to hit, to pick a lock, to cast - was slightly harder than it should have been. Where the difficulty sat a point above the skill, a critical success was not merely rare but impossible.


### PR DESCRIPTION
Projectiles the player fires added charLevel / 4 to their damage. The original adds nothing for the level, on missiles or in melee.

Details
-------

The chain that works out a projectile's damage was read end to end - UW.EXE 0x2b2bd, 0x258cf and 0x24cb5, each from its prologue to its lret
- and the level, the byte at 0x3d of the struct at DS:0x7270, is read in none of the three.

Checked in game at level 13: a sling stone's boost came out as the Missile term alone and a magic missile's as the Casting term alone. That stone would have hit for five on the old code instead of two.