### PR TITLE
Player: recompute the hit point maximum from the level

### DIFF
--- a/Assets/Game/Scripts/CreateCharacter.cs
+++ b/Assets/Game/Scripts/CreateCharacter.cs
@@ -187,9 +187,7 @@ public class CreateCharacter : MonoBehaviour
                 break;
             }
         }
-        // https://wiki.ultimacodex.com/wiki/Character_attributes#Ultima_Underworld_and_Ultima_Underworld_II
-        int strength = PlayerData.sData.strength;
-        PlayerData.sData.vitality = 29 + (6 * strength + 3) / 25;
+        PlayerData.sData.vitality = PlayerObject.GetMaxHitPoints();
         PlayerData.sData.hp = PlayerData.sData.vitality;
 
         for (int i = 0; i < PlayerData.sData.skill.Length; ++i)

--- a/Assets/Game/Scripts/PlayerObject.cs
+++ b/Assets/Game/Scripts/PlayerObject.cs
@@ -1526,6 +1526,16 @@ public class PlayerObject : MonoBehaviour
 
     // Awards skill points for newly crossed 300-display-XP tiers and character levels.
     // Uses a high-water XP tier so sapling XP penalties do not re-award the same tiers.
+    /// <summary>
+    /// The maximum hit points: level * Strength / 5 + 30, the multiply before the divide, as
+    /// the original works it out from scratch whenever the level changes (UW.EXE 0x81305,
+    /// reached from the level-up routine 0x8138a, both read whole).
+    /// </summary>
+    public static int GetMaxHitPoints()
+    {
+        return PlayerData.sData.charLevel * PlayerData.sData.strength / 5 + 30;
+    }
+
     public static void ApplyXpProgress()
     {
         int displayXp = PlayerData.sData.xp / 20;
@@ -1543,9 +1553,13 @@ public class PlayerObject : MonoBehaviour
             int levelsGained = newLevel - PlayerData.sData.charLevel;
             PlayerData.sData.charLevel = newLevel;
             Messages.Add($"{StringLoader.GetString(1, 147)}{PlayerData.sData.charLevel}.");
-            int vitalityIncrease = PlayerData.sData.strength / 5;
-            PlayerData.sData.vitality += vitalityIncrease;
-            PlayerData.sData.hp += vitalityIncrease;
+            int previousMax = PlayerData.sData.vitality;
+            PlayerData.sData.vitality = GetMaxHitPoints();
+            // The original raises the ceiling and leaves the current total alone, but the
+            // flask is drawn as 13 * hp / vitality, so that would empty two of its thirteen
+            // segments at every level, even at full health. Kept as it was: what the ceiling
+            // gains, the current total gains.
+            PlayerData.sData.hp += Mathf.Max(0, PlayerData.sData.vitality - previousMax);
             PlayerData.sData.skillPoints += levelsGained;
             Music.LevelUp();
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Maximum hit points now grow with the character's level, as the original's do, instead of gaining a fixed step each time. A character with Strength 14 reached level 16 twelve points short - a sixth of the total - and the shortfall grew with every level.
+
 - A projectile the player fires no longer does extra damage for the character's level, which the original adds neither to missiles nor to melee. It was a quarter of the level, so at level 13 a sling stone hit for five where the stone itself is worth two.
 
 - Mantras at a shrine no longer hand out an extra point on the seven skills governed by Strength, the way the original withholds it there and nowhere else. The mana ceiling now uses the game's own formula rather than one from a wiki, and saying the mana mantra no longer tops the pool back up.


### PR DESCRIPTION
The maximum was fixed at character creation from a wiki formula and then raised by Strength / 5 at each level. The original works it out from scratch every time the level changes, level * Strength / 5 + 30, so the remainder that the per-level step throws away is never lost.

Details
-------

UW.EXE 0x81305 holds the derived stats and 0x8138a, the level-up routine, is what calls it; both read from their prologue to the lret. The two agree wherever Strength is a multiple of five and part company everywhere else: at Strength 14 the sixteenth level came out twelve points short, a sixth of the total, and the gap widened with each level. The starting value also differed by one for six Strengths in twenty-one.

This lines up with what the game's page already says about it: maxMana recomputes when the Mana skill changes and carryWeight recomputes every frame, while maxHP was described there as not recalculating and simply gaining a delta at each level. It recalculates now. One case is still outside it - a conversation can write Strength, and nothing recomputes until the next level - because what the original does on that path has not been read.

Levelling still heals by what the ceiling gained, which the original does not do: 0x8138a raises the level, hands the derived stats to 0x81305 and does nothing else, its one remaining call being a seven instruction screen refresh. Kept because the flask is drawn as 13 * hp / vitality, so taking it away would empty two of the thirteen segments at every level even at full health. That is a change of its own, not this one.

Checked in game on a fighter with Strength 22: 34 at creation, 38 at the second level and 43 at the third. The third is the first level at which the two ways of counting part company - the old one reaches 42 there - and they never meet again.