### PR TITLE
Combat: creatures now use the armour in their own data

### DIFF
--- a/Assets/Game/Scripts/Critter.cs
+++ b/Assets/Game/Scripts/Critter.cs
@@ -313,7 +313,7 @@ public class Critter : UUObject
     // Bit 2 of critterData[6]: a marker the level designers put on 138 of the 872 placed creatures,
     // and which nothing in UW.EXE ever sets or clears. One branch of the original (0x25a7b) gates
     // two bonuses on it, +7..12 on the attack score and +4..15 on the damage; the other 84% get
-    // neither. It also multiplies the creature's own armour by 5/3 (0x24e03), which is not used yet.
+    // neither. It also multiplies the creature's own armour by 5/3, in GetArmourByBodyPart().
     public bool elite;
 
     public float walkSpeed = 1.0f;
@@ -3416,6 +3416,71 @@ public class Critter : UUObject
             : transform.position.y;
     }
 
+    /// <summary>
+    /// The protection covering one body part. The four bytes at the head of the creature's record
+    /// in OBJECTS.DAT are one value per part, and the original reads the one for the part that was
+    /// hit (UW.EXE 0x24dc1). A slot holding 255 means "the torso's", and the original falls back
+    /// to byte 0 for it (0x24dcc); seventeen of the sixty-four creatures are written that way -
+    /// rotworm, bats, rats, slugs, imp, mongbat, bloodworm, lurkers, ghosts, gazer, wisp - so
+    /// without that branch they would carry 255 everywhere but the torso, which is to say they
+    /// would be untouchable by anything that struck them elsewhere.
+    /// The marked creatures wear theirs at 5/3, and only they: the original skips that step when
+    /// the target is the player (0x24deb, 0x24e03).
+    /// </summary>
+    public int GetArmourByBodyPart(EBodyPart part)
+    {
+        int[] armour = stats.Armour;
+        if (armour == null)
+        {
+            return 0;
+        }
+
+        int protection = armour[(int)part];
+        if (protection == 255)
+        {
+            protection = armour[(int)EBodyPart.Torso];
+        }
+
+        if (elite)
+        {
+            protection = protection * 5 / 3;
+        }
+
+        return protection;
+    }
+
+    /// <summary>
+    /// Which body part a blow arriving at <paramref name="strikeHeight"/> lands on, measured
+    /// against this creature's own capsule. <see cref="Utils.PickBodyPart"/> holds the rule.
+    /// </summary>
+    public EBodyPart PickBodyPart(float strikeHeight)
+    {
+        CharacterController body = cachedCharacterController;
+        if (body == null)
+        {
+            return EBodyPart.Torso;
+        }
+
+        float middle = transform.TransformPoint(body.center).y;
+        return Utils.PickBodyPart(strikeHeight, middle - 0.5f * body.height, middle + 0.5f * body.height);
+    }
+
+    /// <summary>
+    /// Takes the protection covering the body part the blow landed on off the damage, floored at
+    /// zero (UW.EXE 0x24e14). One routine does this for whoever is being hit, so a creature's own
+    /// armour works exactly the way the player's does in
+    /// <see cref="PlayerObject.AbsorbWithArmour"/> - it does not stop blows from landing, it stops
+    /// them from hurting.
+    /// Only a swing and a missile go through it. The original's damage routine has two callers,
+    /// 0x2527e for a melee blow and 0x259e7 for a missile impact, and it is one of nineteen ways
+    /// into the routine that spends hit points: spells, poison, falls and traps reach that one
+    /// directly and armour never sees them.
+    /// </summary>
+    public int AbsorbWithArmour(int damage, float strikeHeight)
+    {
+        return Mathf.Max(0, damage - GetArmourByBodyPart(PickBodyPart(strikeHeight)));
+    }
+
     void TryDamageTarget()
     {
         if (GetDistanceToTarget() > meleeAttackRange + meleeAttackHysteresis)
@@ -3500,6 +3565,7 @@ public class Critter : UUObject
             }
             else
             {
+                damage = attackTarget.AbsorbWithArmour(damage, GetSwingHeight());
                 attackTarget.TryDamage(damage, result);
             }
             break;

--- a/Assets/Game/Scripts/PlayerObject.cs
+++ b/Assets/Game/Scripts/PlayerObject.cs
@@ -177,11 +177,9 @@ public class PlayerObject : MonoBehaviour
     }
 
     /// <summary>
-    /// Which body part a blow arriving at <paramref name="strikeHeight"/> lands on. The original
-    /// compares that height with the vertical extent of what it is hitting (UW.EXE 0x2441a): under
-    /// the feet is legs, over the head is head, and in between the split leans low or high
-    /// depending on which of the two is taller. So a rotworm goes for the legs and an imp for the
-    /// head, and the armour that answers is the one covering that part.
+    /// Which body part a blow arriving at <paramref name="strikeHeight"/> lands on, measured
+    /// against the player's own capsule. <see cref="Utils.PickBodyPart"/> holds the rule, which
+    /// the original applies to whoever is being hit.
     /// </summary>
     public EBodyPart PickBodyPart(float strikeHeight)
     {
@@ -192,32 +190,31 @@ public class PlayerObject : MonoBehaviour
         }
 
         float middle = transform.TransformPoint(body.center).y;
-        float foot = middle - 0.5f * body.height;
-        float head = middle + 0.5f * body.height;
+        return Utils.PickBodyPart(strikeHeight, middle - 0.5f * body.height, middle + 0.5f * body.height);
+    }
 
-        if (strikeHeight < foot)
-        {
-            return EBodyPart.Legs;
-        }
-
-        if (strikeHeight > head)
-        {
-            return EBodyPart.Head;
-        }
-
-        if (strikeHeight < middle)
-        {
-            if (Random.Range(0, 2) == 0)
-            {
-                return EBodyPart.Legs;
-            }
-        }
-        else if (Random.Range(0, 3) == 0)
-        {
-            return EBodyPart.Head;
-        }
-
-        return Random.Range(0, 3) == 0 ? EBodyPart.Arms : EBodyPart.Torso;
+    /// <summary>
+    /// The height the player's own blow arrives at, which is what decides where on a creature it
+    /// lands. The original works this out from the player's footing and build and hands it to the
+    /// same part picker a creature's swing uses (UW.EXE 0x24876), so the mirror of
+    /// Critter.GetSwingHeight() is the right shape.
+    /// It leaves out one term the original adds only when the swinger is the player, at UW.EXE
+    /// 0x24908: a quarter of the view pitch, which is to say that looking up makes a blow land
+    /// higher on what it hits. The original's pitch is one of the three angles of the viewpoint
+    /// (0x31759 fills it from DS:0x3588), clamped to a sixteenth of a turn either way in steps of
+    /// a sixty-fourth, so four notches up and four down; 0x24908 divides it by 512 and adds -8 to
+    /// +8 to the height of the blow, against a player 23 units tall in COMOBJ.DAT - about a third
+    /// of his own height, enough to move a hit from the chest to the head.
+    /// It is left out because the choice of part is worth almost nothing here: of the sixty-four
+    /// creatures forty-one carry the same protection on all four parts and twenty-one vary by a
+    /// single point, so the part chosen costs at most one point of damage to all but two of them.
+    /// Porting it would also be a design decision rather than a transcription, since mouse look
+    /// here is continuous where the original has four notches.
+    /// </summary>
+    public float GetSwingHeight()
+    {
+        CharacterController body = cachedCharacterController;
+        return body != null ? transform.TransformPoint(body.center).y : transform.position.y;
     }
 
     public static void LoadSkills()

--- a/Assets/Game/Scripts/Projectile.cs
+++ b/Assets/Game/Scripts/Projectile.cs
@@ -189,6 +189,10 @@ public class Projectile : UUObject
                     Critter critter = root.GetComponent<Critter>();
                     if (critter != null)
                     {
+                        // Same routine as a swing in the original (UW.EXE 0x259e7 and 0x2527e both
+                        // call 0x24cb5), and the missile path picks a body part of its own before
+                        // it gets there (0x25988), so a creature's armour soaks an arrow too.
+                        damage = critter.AbsorbWithArmour(damage, transform.position.y);
                         critter.TryDamage(damage, Skills.ESkillTestResult.Success);
                         PlayerObject.Player.SetLastEngagedInCombat(critter);
                     }

--- a/Assets/Game/Scripts/Utils.cs
+++ b/Assets/Game/Scripts/Utils.cs
@@ -185,6 +185,44 @@ public class Utils
         }
     }
 
+    /// <summary>
+    /// Which body part a blow arriving at <paramref name="strikeHeight"/> lands on, for a target
+    /// standing between <paramref name="foot"/> and <paramref name="head"/>. The original compares
+    /// the middle of the swing with the middle of what it is hitting (UW.EXE 0x2441a): below the
+    /// feet is legs, above the head is head, and in between the split leans low or high depending
+    /// on which side of the middle the blow arrived on. So a rotworm goes for the legs and an imp
+    /// for the head, and the protection that answers is the one covering that part.
+    /// One routine picks the part whoever is swinging: the melee path reaches it at 0x24a2e and
+    /// the missile path at 0x25988, and both then read the protection at 0x24dc1. That is why the
+    /// player and a creature ask the same question here.
+    /// </summary>
+    public static EBodyPart PickBodyPart(float strikeHeight, float foot, float head)
+    {
+        if (strikeHeight < foot)
+        {
+            return EBodyPart.Legs;
+        }
+
+        if (strikeHeight > head)
+        {
+            return EBodyPart.Head;
+        }
+
+        if (strikeHeight < 0.5f * (foot + head))
+        {
+            if (Random.Range(0, 2) == 0)
+            {
+                return EBodyPart.Legs;
+            }
+        }
+        else if (Random.Range(0, 3) == 0)
+        {
+            return EBodyPart.Head;
+        }
+
+        return Random.Range(0, 3) == 0 ? EBodyPart.Arms : EBodyPart.Torso;
+    }
+
     public static int GetDamageRoll(int maxDamage)
     {
         int numD6 = maxDamage / 6;

--- a/Assets/Game/Scripts/WeaponBase.cs
+++ b/Assets/Game/Scripts/WeaponBase.cs
@@ -656,11 +656,21 @@ public class WeaponBase : UUObject
 
                     //Debug.Log($"Damage: max {maxDamage}; roll {rolledDamage}; prep {prepTime}; scale {scaledForDamage}; dam {damage}");
 
+                    Critter critter = obj as Critter;
+                    if (critter != null)
+                    {
+                        // The creature's own armour eats the blow, the same way the player's eats
+                        // one coming the other way: the original runs both through one routine and
+                        // subtracts the protection covering wherever the blow landed
+                        // (UW.EXE 0x24dc1, 0x24e14).
+                        damage = critter.AbsorbWithArmour(damage, PlayerObject.Player.GetSwingHeight());
+                    }
+
                     obj.TryDamage(damage, res);
                 
                     PlayerObject.Rumble(0.05f, 0.4f, 0.2f);
                 
-                    if (obj is Critter critter)
+                    if (critter != null)
                     {
                         PlayerObject.Player.SetLastEngagedInCombat(critter);
                         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Creatures now wear the armour their own data gives them, which nothing had been reading, so a blow that lands loses the protection covering the part it struck and one that cannot get through does no harm at all. Fights are harder and longer for it, and closer to the original: most creatures shrug off one to five points of every hit, and a headless turns out to be best protected exactly where it has no head.
+
 - Maximum hit points now grow with the character's level, as the original's do, instead of gaining a fixed step each time. A character with Strength 14 reached level 16 twelve points short - a sixth of the total - and the shortfall grew with every level.
 
 - A projectile the player fires no longer does extra damage for the character's level, which the original adds neither to missiles nor to melee. It was a quarter of the level, so at level 13 a sling stone hit for five where the stone itself is worth two.


### PR DESCRIPTION
The four bytes at the head of a creature's record in OBJECTS.DAT are its protection, one value per body part, and nothing ever read them, so every blow the player landed cost a creature its whole rolled damage - while the player's own armour had already been put back to work on the other side. This takes the protection covering the part a blow struck off the damage, floored at zero, as the original does in the one routine both sides go through (UW.EXE 0x24dc1 for the lookup, 0x24e14 for the subtraction).

Fights last longer and reward a heavy weapon held to full charge, and the combat comes out feeling much closer to the original than it did. Over the 524 placed creatures that fight, a fully charged longsword loses about a quarter of its damage to armour and a tapped one about a third: a goblin turns aside two or three points of every blow, a stone golem five.

Details
-------

What to expect. Same character throughout, a longsword and Strength 27. Before this change a blow was worth its whole roll, 11.25 on average held to full charge and 8.00 tapped, whatever it hit. What it is worth now:

                        damage per blow  blows to kill
                  arm     full tapped     full tapped     hp
    giant rat       1    10.25   7.00        1      2     13
    goblin          3     7.99   4.76        4      7     31
    headless        3     7.40   4.26        7     12     50
    feral troll     4     7.11   3.90        9     17     65
    stone golem     5     6.45   3.27       19     38    125
    metal golem     7     4.45   1.55       45    129    200

The small creatures barely notice; the change grows with the armour rather than with the hit points. The two charge columns are the point: a tapped blow used to cost about a third of the damage and now costs two thirds or more, because the protection comes off a smaller number. Marked creatures wear theirs at 5/3, and only they - the original skips that step when the target is the player (0x24deb, 0x24e03).

A 255 in a slot means the torso's value. Seventeen of the sixty-four creatures are written [n, 255, 255, 255], the small and insubstantial ones - rats, bats, slugs, worms, ghosts - and the original falls back to byte 0 for them (0x24dcc). Read as written they would carry 255 points everywhere but the torso, which is to say be untouchable.

Where it applies. The damage routine has two callers, a melee blow at 0x2527e and a missile impact at 0x259e7, and is one of nineteen ways into the routine that spends hit points - spells, poison, falls and traps reach that one directly. So the absorption goes on the swing and the arrow and nowhere else, which is where the player's already sits.

Nothing becomes unkillable. The hardest creature that starts hostile is a metal golem, 45 blows with a longsword and 15 with a jewelled mace - which is the original's bargain, armour being what makes a heavy weapon worth its slowness.

Left out of this change: aiming. The original also adds a quarter of the view pitch to the height of a player's blow (0x24908), so looking up makes a sword land higher. It belongs in a change of its own.

Checked in play, exactly rather than statistically: 59 absorbed blows logged, and in all 59 the protection used matches OBJECTS.DAT and the damage is max(0, raw - protection). The clearest case is a marked fighter, thirteen consecutive blows on one target: its record holds [5, 4, 4, 4], the log shows 8 on the torso and 6 elsewhere - which is 5*5/3 and 4*5/3 and nothing else - and the hit points fall by exactly the damage of each line, three of the thirteen by nothing at all. A cave bat, one of the seventeen with the sentinel, was struck on legs, arms and head and answered 1 every time.

Verified against the original. 0x24cb5 read whole, prologue to lret, 334 instructions, and so were 0x24876 and 0x2441a, which pick the body part, and the missile path 0x258cf; callers enumerated in every encoding. The table base 0x4a52 appears 20 times in the file and only twice as a read of those four bytes, both inside 0x24cb5 and both after the charge scale.