### PR TITLE
Combat: restore the weapon's own charge timing and scaling

### DIFF
--- a/Assets/Game/Scripts/WeaponBase.cs
+++ b/Assets/Game/Scripts/WeaponBase.cs
@@ -289,14 +289,17 @@ public class WeaponBase : UUObject
             }
             else if (attackHeld && !panelBlocksWeapon)
             {
-                bool wasPrepared = prepareTime > 0.5f;
-                float chargeSpeed = GetChargeSpeed();
-                prepareTime += Time.deltaTime * chargeSpeed;
-                if (!wasPrepared && prepareTime > 0.5f)
+                bool wasWoundUp = prepareTime > WindUpSeconds;
+                prepareTime += Time.deltaTime;
+                if (!wasWoundUp && prepareTime > WindUpSeconds)
                 {
                     Utils.PlayClip2d(prepareSound);
                 }
-                WeaponChargeGem.sChargeGem.power = Mathf.Clamp(prepareTime - 0.5f, 0.0f, 1.0f);
+
+                // The gem shows the charge itself, so it stays dark through the wind-up - where a
+                // release throws the swing away here and in the original alike - and then climbs
+                // in the same steps the charge does.
+                WeaponChargeGem.sChargeGem.power = GetChargePercent() / 100.0f;
 
                 if (cancelPressed)
                 {
@@ -306,7 +309,7 @@ public class WeaponBase : UUObject
             }
             else
             {
-                if (prepareTime > 0.5f)
+                if (prepareTime > WindUpSeconds)
                 {
                     ChangeState(EState.Swing);
                 }
@@ -500,28 +503,57 @@ public class WeaponBase : UUObject
         }
     }
 
-    private float GetChargeSpeed()
+    /// <summary>
+    /// The pause between the button going down and the charge starting to build. The original
+    /// spends it raising the weapon, on the same 32-tick mask the charge's clock drives: the
+    /// click arms the animation's bit at once (UW.EXE 0x3210b), the dispatcher runs it on the
+    /// next boundary (0x32145), and its state counter has to climb before the charge starts
+    /// accumulating (0x330c9). A release inside it throws the swing away rather than landing a
+    /// weak blow, here and in the original alike (0x255ca, the branch for that counter below 3).
+    /// </summary>
+    /// <remarks>
+    /// 176 ticks, and the last word here is play rather than the listing. Reading the state
+    /// machine accounts for 112 - half a boundary's wait on average plus three whole periods -
+    /// and timing the original gives 64 more, which is two more periods somewhere between the
+    /// click and the animation being asked for. Where they go has not been found, so the number
+    /// is the measured one and this note is the reason it is not the counted one.
+    /// </remarks>
+    private const float WindUpSeconds = 0.6875f;
+
+    /// <summary>
+    /// One step of the charge. The original adds the weapon's WeaponSpeed byte to a percentage
+    /// once every 16 ticks of that same clock and stops at a hundred (UW.EXE 0x2574e, clamped at
+    /// 0x25752), so the charge climbs in steps rather than smoothly and the number of steps is
+    /// ceil(100 / WeaponSpeed) - a dagger at 30 and a hand axe at 25 both take four of them.
+    /// </summary>
+    /// <remarks>
+    /// Both constants are in seconds, which the original is not: it counts ticks of a clock whose
+    /// rate the executable does not fix, since a timer library reprograms the PIT for whatever
+    /// period is asked of it. The rate comes instead from the gap between two weapons timed by
+    /// hand under DOSBox - a battle axe at two seconds and a dagger at one, 320 ticks of charge
+    /// against 64, so 256 ticks are a second and a tick is 1/256s. A stopwatch adds the same
+    /// constant to both readings and it cancels in the difference, which is why the gap pins the
+    /// rate where a single reading could not. It also lands on a round number, and on a
+    /// prediction: a long sword should take 1.19s, and measured 1.20 afterwards.
+    /// </remarks>
+    private const float ChargeStepSeconds = 0.0625f;
+
+    /// <summary>How quickly this weapon builds an attack charge, on the data's 5-30 scale.</summary>
+    protected virtual int GetWeaponSpeed()
     {
-        ObjectsData.MeleeData meleeData = DataLoader.sDataLoader.objectsData.weaponStats[(int)type & 15];
-        
-        // WeaponSpeed ranges from 5-30 (higher = faster)
-        float weaponSpeedNormalized = (meleeData.WeaponSpeed - 5.0f) / 25.0f; // 0.0 to 1.0
-        
-        // Skills range from 0-30 (higher = faster)
-        float attackSkillNormalized = Skills.GetSkill(ESkill.Attack) / 30.0f; // 0.0 to 1.0
-        float dexterityNormalized = PlayerData.sData.dexterity / 30.0f; // 0.0 to 1.0
-        float weaponSkillNormalized = Skills.GetSkill(skill) / 30.0f; // 0.0 to 1.0
-        
-        // Base speed: 0.5x to 2.0x multiplier based on weapon speed
-        // Skill bonus: up to 1.5x additional multiplier from skills
-        float baseSpeed = 0.5f + weaponSpeedNormalized * 1.5f;
-        float skillBonus = (attackSkillNormalized + dexterityNormalized + weaponSkillNormalized) / 3.0f * 1.5f;
-        
-        float chargeSpeed = baseSpeed + skillBonus;
-        
-        // Clamp chargeSpeed so time to reach prepareTime = 1.0 ranges from 0.1s to 5s
-        // time = 1.0 / chargeSpeed, so chargeSpeed must be between 0.2 and 10.0
-        return Mathf.Clamp(chargeSpeed, 0.2f, 10.0f);
+        return DataLoader.sDataLoader.objectsData.weaponStats[(int)type & 15].WeaponSpeed;
+    }
+
+    /// <summary>How far the charge has climbed for the hold so far, from 0 to 100.</summary>
+    private int GetChargePercent()
+    {
+        if (prepareTime <= WindUpSeconds)
+        {
+            return 0;
+        }
+
+        int steps = (int)((prepareTime - WindUpSeconds) / ChargeStepSeconds);
+        return Mathf.Clamp(steps * GetWeaponSpeed(), 0, 100);
     }
 
     /// <summary>True when the player is preparing, swinging, in post-swing, or within 2 seconds of finishing a swing (sprint blocked).</summary>
@@ -644,7 +676,7 @@ public class WeaponBase : UUObject
                     ObjectsData.MeleeData meleeData =  DataLoader.sDataLoader.objectsData.weaponStats[(int)type & 15];
                     int maxDamage = GetMaxDamage();
                     int rolledDamage = Utils.GetDamageRoll(maxDamage);
-                    int prepTime = (int)(100.0f * Mathf.Clamp(prepareTime - 0.5f, 0.0f, 1.0f));
+                    int prepTime = GetChargePercent();
                     int scaledForDamage = meleeData.MinCharge +
                                           (meleeData.MaxCharge - meleeData.MinCharge) * prepTime / 100;
                     int damage = scaledForDamage * rolledDamage / 128;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- How long a weapon takes to wind up now depends on the weapon alone, as the original has it, and not on the character's skills as well: a trained fighter used to charge a battle axe in under a second, and it now takes the same two it takes a beginner. Every swing also opens with a short raise that no weapon skips and that a release cuts short, so the distance between the lightest weapon and the heaviest is the two to one the original asks for instead of the near-parity it drifted into.
+
 - Creatures now wear the armour their own data gives them, which nothing had been reading, so a blow that lands loses the protection covering the part it struck and one that cannot get through does no harm at all. Fights are harder and longer for it, and closer to the original: most creatures shrug off one to five points of every hit, and a headless turns out to be best protected exactly where it has no head.
 
 - Maximum hit points now grow with the character's level, as the original's do, instead of gaining a fixed step each time. A character with Strength 14 reached level 16 twelve points short - a sixth of the total - and the shortfall grew with every level.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ I removed a number of store-bought assets before pushing this to github, so it m
   - achievements
   - gamepad support
   - three ratings added to the inventory panel: attack by the weapon hand, defence and armour by the shield hand
+  - clearer attack feedback: the charge cursor stays dark until a release would actually land a swing, then lights up and fills
 


### PR DESCRIPTION
Winding a weapon up was wrong in three ways that live in the same few lines, and the shape underneath them is now taken from the original rather than guessed at.

  - Attack, dexterity and the weapon skill added up to 1.5 on top of the weapon's own speed. The original has nothing of the kind, and it closed the gap as the character grew: at maximum skill the heaviest sword wound up almost as fast as a dagger.
  - There was no wind-up. Every weapon now pays the same two thirds of a second before the charge starts to build, which is most of what separates a swing that feels weighty from one that fires on contact.
  - The charge climbed smoothly. The original's climbs in steps of WeaponSpeed, so the number of steps is ceil(100 / WeaponSpeed) and a dagger at 30 takes four of them, the same four as a hand axe at 25.

Details
-------

What to expect. Every weapon keeps the same maximum damage; what changes is how long it takes to get there, and it is now the weapon alone that decides. The before column is a character with no skill at all; a practised one used to get every one of these under a second.

                     ws   before     now
    dagger           30    0.75s    0.94s
    hand axe         25    0.88s    0.94s
    shortsword       20    1.07s    1.00s
    longsword        15    1.36s    1.13s
    mace              9    2.03s    1.44s
    battle axe        5    3.00s    1.94s

The spread between the lightest weapon and the heaviest is 2.1 to 1 rather than the 1.7 it had fallen to at full skill, and a character no longer outgrows it: those numbers are the same at skill 0 and at skill 30.

Where the two constants come from. The original counts ticks of a clock whose rate the executable does not fix - a timer library reprograms the PIT for whatever period the loudest of its seventeen clients asks for - so both were taken from play, timed by hand under DOSBox. The step came from the gap between two weapons rather than from one reading, since a stopwatch adds the same constant to both and it cancels in the difference: a battle axe and a dagger are 320 and 64 ticks of charge apart and measured two seconds and one apart, which puts a tick at 1/256s and the step at 62.5ms. The wind-up is 176 of those ticks. Reading the state machine accounts for 112 of them and play insists on 176, so two periods of it are unexplained; the number here is the measured one. What that costs is the pace, not the shape: every weapon moves by the same amount and the ratios between them are the step's alone.

Checked against the original. The charge lives in one function, 0x255ca, read end to end, and si is the weapon's row: the pointer at 0x267e, filled by 0x25326 as 0x5972 + 8 * (type & 15), whose offsets 3, 4 and 5 are MinCharge, WeaponSpeed and MaxCharge. The percentage at 0x2662 has eight references in the whole executable, all inside that function, and the only accumulation is += byte[si+4]: no skill, no attribute, no enchantment. The accumulator reads the same clock the animation dispatcher reads, which is what fixes one animation step at two charge steps.

Checked in play. Fifteen charges timed to the frame across eight weapons, and every one of them within a frame of what its constants predict: the machinery does what the formula says. A battle axe carried at two different Axe values comes out the same to a hundredth of a second, where on main it differed by 73 milliseconds. The constants rest on five weapons timed in the original and on what the same stopwatch reads back here: against this build's own logging it runs 0.08s late, small enough that the two sets of readings compare directly.