### PR TITLE
Combat: restore missile's damage, skill multiplier and minimum damage

### DIFF
--- a/Assets/Game/Scripts/ObjectsData.cs
+++ b/Assets/Game/Scripts/ObjectsData.cs
@@ -22,11 +22,31 @@ public class ObjectsData
         public short Durability;
     };
 
-    public struct RangedData
+    public struct MissileData
     {
-        public int ammo;
-        public int unk;
+        /* One 16 x 3 table covering object types 16-31, indexed by type & 15 like the melee table:
+           the eight projectiles (16-23) first, then the eight launchers (24-31).
+
+           0000   Int8   damage, for a projectile; 3 for every launcher, so meaningless there
+           0001   Int8   unknown
+           0002   Int8   one byte read two ways, and the half it belongs to decides which
+
+           The launcher half checks out: the ammunition values give sling -> sling stone,
+           bow -> arrow, crossbow -> crossbow bolt and jewelled bow -> arrow, which is the mapping
+           RangedWeapon.GetAmmoType() spells out by hand.
+
+           On a projectile row the same byte is the kind of damage the missile does, kept negated:
+           the original negates it (UW.EXE 0x2b355) and hands it to the routine that asks whether
+           the target resists that kind, where acid's bit is the one poison uses too. It also
+           tests the byte itself for exactly 0xC0 before letting the Missile skill scale the
+           damage (0x2b2e6), and 0xC0 is what all four physical missiles carry - the sling stone,
+           the crossbow bolt, the arrow and the stone - against 0xF5, 0xDD, 0xF0 and 0xBD on the
+           fireball, the lightning bolt, the acid and the magic missile. That one test is how the
+           original keeps the character out of a spell's damage. */
         public int damage;
+        public int unk;
+        public int ammo;
+        public int marker;
     }
 
     public struct ArmourData
@@ -157,7 +177,7 @@ this byte of his own row (UW.EXE 0x7e535 and 0x7e5f8); armour is not part of it.
     }
     
     public MeleeData[] weaponStats = new MeleeData[16];
-    public RangedData[] rangedStats = new RangedData[8];
+    public MissileData[] missileStats = new MissileData[16];
     public ArmourData[] armourStats = new ArmourData[32];
     public ContainerData[] containerStats = new ContainerData[16];
     public LightSourceData[] lightSourceStats = new LightSourceData[8];
@@ -183,17 +203,12 @@ this byte of his own row (UW.EXE 0x7e535 and 0x7e5f8); armour is not part of it.
             weaponStats[i].Durability = stream.GetByte();
         }
         
-        for (int i = 0; i < rangedStats.Length; ++i)
+        for (int i = 0; i < missileStats.Length; ++i)
         {
-            rangedStats[i].damage = stream.GetByte();
-            stream.Skip(2);
-        }
-
-        for (int i = 0; i < rangedStats.Length; ++i)
-        {
-            rangedStats[i].damage = stream.GetByte();
-            rangedStats[i].unk = stream.GetByte();
-            rangedStats[i].ammo = stream.GetByte() + 16; // index into ranged table
+            missileStats[i].damage = stream.GetByte();
+            missileStats[i].unk = stream.GetByte();
+            missileStats[i].marker = stream.GetByte();
+            missileStats[i].ammo = missileStats[i].marker + 16; // stored as an offset into them
         }
 
         for (int i = 0; i < armourStats.Length; ++i)

--- a/Assets/Game/Scripts/Projectile.cs
+++ b/Assets/Game/Scripts/Projectile.cs
@@ -212,84 +212,102 @@ public class Projectile : UUObject
         }
     }
 
-    private int GetDamageSkillBoost()
+    /// <summary>
+    /// The Missile skill scales a physical missile's damage rather than adding to it, and the
+    /// scale is a fraction of 256: 192 with no skill at all, eight more for every point of it.
+    /// So an untrained shot does three quarters of the table's damage and a fully trained one
+    /// a little over one and two thirds (UW.EXE 0x2b2ec-0x2b32b, read whole).
+    /// </summary>
+    private const int MissileScaleUntrained = 192;
+    private const int MissileScalePerPoint = 8;
+    private const int MissileScaleUnit = 256;
+
+    /// <summary>
+    /// Every shot the player takes rolls the skill at this difficulty, and only the two critical
+    /// outcomes move the scale - by which the worst a trained archer can do is still better than
+    /// the best an untrained one manages.
+    /// </summary>
+    private const int MissileRollDifficulty = 10;
+    private const int MissileScaleCriticalFailure = -128;
+    private const int MissileScaleCriticalSuccess = 192;
+
+    /// <summary>
+    /// The marker the missile table carries on the four physical projectiles. The original tests
+    /// the row's third byte for exactly this before letting any of the character into the sum,
+    /// which is how a fireball ends up owing nothing to the mage who cast it.
+    /// </summary>
+    private const int PhysicalMissileMarker = 0xC0;
+
+    /// <summary>
+    /// Nothing is ever rolled against a maximum lower than this: the routine that rolls the
+    /// damage lifts one up to two before it starts (UW.EXE 0x24cd9). Melee shares that routine,
+    /// but with this game's data only a scaled missile can arrive under two - a sling stone whose
+    /// skill roll came out a critical failure below Missile 5 - so this is where it belongs. The
+    /// unscaled rows are all five or more.
+    /// </summary>
+    private const int MinimumRolledMaximum = 2;
+
+    /// <summary>
+    /// The most damage this shot can do, before the roll: the missile table's own byte, scaled
+    /// by the Missile skill where the row allows it.
+    /// </summary>
+    private int GetMaxDamage()
     {
-        // The original adds nothing per character level, here or in melee: the chain that
-        // works out a projectile's damage - UW.EXE 0x2b2bd, 0x258cf and 0x24cb5, each read
-        // whole - never reads the level, the byte at P1[0x3d].
-        int damage = 0;
-        switch (type)
+        // Object types 16-23 are the eight rows of the missile table that carry a damage value;
+        // 24-31 are the launchers, whose byte reads 3 and means nothing.
+        if ((int)type < 16 || (int)type > 23)
         {
-        case EObjectType.MagicMissile:
-            damage += Skills.GetSkill(ESkill.Casting) / 6;
+            return 0;
+        }
+
+        ObjectsData.MissileData row = DataLoader.sDataLoader.objectsData.missileStats[(int)type & 15];
+
+        // Neither a creature's shot nor a spell takes anything from the player's skill. The
+        // original decides both at once: it scales only when the shot is the player's and the
+        // row carries the physical marker.
+        if (projectileOwner != PlayerObject.Player.gameObject || row.marker != PhysicalMissileMarker)
+        {
+            return row.damage;
+        }
+
+        int missile = Skills.GetSkill(ESkill.Missile);
+        int scale = MissileScaleUntrained + MissileScalePerPoint * missile;
+        switch (Skills.GetResult(missile, MissileRollDifficulty))
+        {
+        case Skills.ESkillTestResult.CriticalFailure:
+            scale += MissileScaleCriticalFailure;
             break;
-        case EObjectType.LightningBolt:
-            damage += Skills.GetSkill(ESkill.Casting) / 5;
-            break;
-        case EObjectType.Fireball:
-            damage += Skills.GetSkill(ESkill.Casting) / 4;
-            break;
-        case EObjectType.SlingStone:
-            damage += Skills.GetSkill(ESkill.Missile) / 6;
-            break;
-        case EObjectType.Arrow:
-            damage += Skills.GetSkill(ESkill.Missile) / 5;
-            break;
-        case EObjectType.CrossbowBolt:
-            damage += Skills.GetSkill(ESkill.Missile) / 4;
+        case Skills.ESkillTestResult.CriticalSuccess:
+            scale += MissileScaleCriticalSuccess;
             break;
         }
 
-        return damage;
-    }
-
-    private int GetBaseDamage()
-    {
-        int damage = 0;
-        switch (type)
-        {
-        case EObjectType.Acid:
-            damage = Random.Range(1, 3);
-            break;
-        case EObjectType.MagicMissile:
-            damage = Random.Range(2, 4);
-            break;
-        case EObjectType.LightningBolt:
-            damage = Random.Range(4, 7);
-            break;
-        case EObjectType.Fireball:
-            damage = Random.Range(6, 9);
-            break;
-        case EObjectType.Knife: // mage weapon
-            damage = Random.Range(3, 6);
-            break;
-        case EObjectType.SlingStone:
-            damage = Random.Range(2, 4);
-            break;
-        case EObjectType.Arrow:
-            damage = Random.Range(3, 5);
-            break;
-        case EObjectType.CrossbowBolt:
-            damage = Random.Range(4, 7);
-            break;
-        }
-
-        return damage;
+        return Mathf.Max(MinimumRolledMaximum, row.damage * scale / MissileScaleUnit);
     }
 
     private int GetDamage()
     {
-        int damage = GetBaseDamage();
-        if (projectileOwner == PlayerObject.Player.gameObject)
+        int damage;
+
+        if (type == EObjectType.Knife)
         {
-            damage += GetDamageSkillBoost();
+            // A mage weapon this project added rather than the original: type 27 lands among the
+            // launchers, which have no damage of their own, so it keeps its hand-written roll.
+            damage = Random.Range(3, 6);
         }
-        
+        else
+        {
+            // The table byte is a maximum and the original rolls it down, the same way and with
+            // the same helper melee damage uses - the two share the routine that finally takes
+            // the hit points off (UW.EXE 0x2b2bd to 0x258cf to 0x24cb5, each read whole).
+            damage = Utils.GetDamageRoll(GetMaxDamage());
+        }
+
         if (createdByCursedEntity)
         {
             damage /= 2;
         }
-        
+
         return damage;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- A missile now does the damage its own row in the game's data gives it, instead of a hand-written number, and the Missile skill multiplies that damage rather than being added to it. Archery is a little weaker at the top and a spell is much stronger everywhere: a fireball averaged seven points for a new mage and fourteen for a practised one, where the original asks for sixteen and a half from both.
+
+- Spells no longer get a damage bonus from the caster's skill, which the original gives to neither spells nor arrows. A fireball is a fireball whoever throws it; what the skill buys is the chance of throwing one at all.
+
 - How long a weapon takes to wind up now depends on the weapon alone, as the original has it, and not on the character's skills as well: a trained fighter used to charge a battle axe in under a second, and it now takes the same two it takes a beginner. Every swing also opens with a short raise that no weapon skips and that a release cuts short, so the distance between the lightest weapon and the heaviest is the two to one the original asks for instead of the near-parity it drifted into.
 
 - Creatures now wear the armour their own data gives them, which nothing had been reading, so a blow that lands loses the protection covering the part it struck and one that cannot get through does no harm at all. Fights are harder and longer for it, and closer to the original: most creatures shrug off one to five points of every hit, and a headless turns out to be best protected exactly where it has no head.


### PR DESCRIPTION
Projectile damage was hand-written and the skill was added to it. The game's data has a row for every missile, and the original reads it and then scales it by the Missile skill - a fraction of 256 rather than a term to add, the same fraction for every missile, and no skill at all on the four magic ones. The level bonus this project used to add went with an earlier change; what is left is the shape underneath.

  - The skill was added, with a different divisor per projectile. The original multiplies, by (192 + 8 * Missile) / 256, and the divisors do not exist: what separates a bolt from a sling stone is the table byte alone.
  - Spells took Casting the same way. The original gives them nothing: what lets the skill into the sum is one exact value in the row's third byte, and the four magic missiles do not carry it.

Details
-------

What to expect, in average damage. S is Missile for the four physical missiles and Casting for the magic ones, as the old code had it.

                      row |  before      |  now
                          |  S=0   S=30  |  S=0   S=30
    sling stone         5 |  2.5    7.5  |  2.0    5.0
    crossbow bolt      10 |  5.0   12.0  |  4.5    9.5
    arrow               8 |  3.5    9.5  |  3.5    8.0
    stone               8 |  0.0    0.0  |  3.5    8.0  (*)
    fireball           28 |  7.0   14.0  | 16.5   16.5
    lightning bolt     16 |  5.0   11.0  |  9.5    9.5
    acid                8 |  1.5    1.5  |  5.0    5.0
    magic missile       8 |  2.5    7.5  |  5.0    5.0

(*) The stone had no case in the old switch and has no instance in the game either, so the hole cost a player nothing.

Archery loses about a fifth at the top and keeps its shape at the bottom. Spells gain everywhere, and the fireball most of all: it was worth half of what the original asks for even to a master, and a quarter of it to a beginner. Damage from a spell no longer moves with the caster at all, which reads oddly until you notice that the original spends the skill on whether the spell goes off, not on what it does when it lands.

An untrained shot now does less than the table says. 192 over 256 is three quarters, so the scale starts below one and only passes it at Missile 8; it reaches one and two thirds at 30. Every shot also rolls the skill against a difficulty of 10, and the two critical outcomes move the scale - down by 128 on a critical failure, up by 192 on a critical success - so a master's worst shot is still better than a beginner's best.

The table byte is a maximum, not a damage. It goes through the same roll melee damage uses, n dice of six plus the remainder, because in the original the two paths meet in one routine before the hit points come off - which is why a fireball's 28 shows up as 16.5 on average. That routine never rolls against less than two, and nothing else in this game's data arrives under two, so the only shot the floor lifts is a sling stone whose skill roll came out a critical failure below Missile five.

Checked against the original: 0x2b2bd to 0x258cf to 0x24cb5, each read from its prologue to its lret, and the table is sixteen rows of three bytes at DS:0x5942, indexed by type & 15 exactly as the melee table is. The data settles the rest - the third byte reads 0xC0 on all four physical missiles and 0xF5, 0xDD, 0xF0 and 0xBD on the four magic ones, while on the launcher rows the same byte is the ammunition, giving sling to sling stone, bow to arrow and crossbow to bolt. The skill read is P1[0x27], which is Missile.

Checked in play, over two sessions and fifty shots logged with the table row, the skill, the scale and the maximum beside the damage actually rolled: every maximum is what the row and the scale say, and no roll ever fell outside it. Both ends of the scale turned up - 560 on a critical success at Missile 22 and 64 on a critical failure at Missile 0 - a creature's own shot came through with the plain table byte, and the floor lifted four shots out of ten from an untrained sling.