### PR TITLE
Combat: restore Unarmed skill bonus to bare hands attack

### DIFF
--- a/Assets/Game/Scripts/WeaponBase.cs
+++ b/Assets/Game/Scripts/WeaponBase.cs
@@ -564,30 +564,59 @@ public class WeaponBase : UUObject
         return Time.time - lastSwingEndTime < 2.0f;
     }
 
+    /// <summary>The largest damage one swing can roll, before the charge scales it.</summary>
+    /// <remarks>
+    /// Bare hands are not a special case in the original: the choice between the two formulas
+    /// comes from the weapon row's own skill byte, clamped into the four melee skills, and the
+    /// fist's row is the only one that falls outside them - it reads 6 where the others read 3,
+    /// 4 or 5 - so bare hands are the only thing that lands on Unarmed. With a weapon the damage
+    /// is the row's value for the attack plus a ninth of Strength; bare-handed it is two fifths
+    /// of Unarmed plus a sixth of Strength plus four, which puts the skill at the head of the sum
+    /// instead of leaving it out (UW.EXE 0x25406, read from its prologue to the lret; the
+    /// bare-handed arm starts at 0x2545e). Strength is read there through the player's row in the
+    /// creature table, whose byte 5 is copied from the attribute at 0x7ddee.
+    /// Only a melee type asks the row: past 15 the rows belong to other weapons, and in the
+    /// original a launcher's shot never comes through this routine at all.
+    /// </remarks>
     public int GetMaxDamage()
     {
         ObjectsData.MeleeData meleeData = DataLoader.sDataLoader.objectsData.weaponStats[(int)type & 15];
-        int weaponDamage = 0;
-        switch (attacks[(int)type & 15])
+
+        int rowSkill = meleeData.Skill;
+        if (rowSkill < (int)ESkill.Unarmed || rowSkill >= (int)ESkill.Missile)
         {
-        case EAttack.Slash:
-            weaponDamage = meleeData.Slash;
-            break;
-        case EAttack.Bash:
-            weaponDamage = meleeData.Bash;
-            break;
-        case EAttack.Stab:
-            weaponDamage = meleeData.Stab;
-            break;
-        }
-        int playerDamage = PlayerData.sData.strength / 9;
-        int weaponBonusDamage = 0;
-        if (isEnchanted && !string.IsNullOrEmpty(enchantmentName) && enchantmentIndex >= 8) // damage enchantment
-        {
-            weaponBonusDamage = 1 + enchantmentIndex - 8;
+            rowSkill = (int)ESkill.Unarmed;
         }
 
-        int maxDamage = weaponDamage + playerDamage + weaponBonusDamage;
+        int maxDamage;
+        if (rowSkill == (int)ESkill.Unarmed && (int)type <= (int)EObjectType.Fist)
+        {
+            maxDamage = 2 * Skills.GetSkill(ESkill.Unarmed) / 5
+                        + PlayerData.sData.strength / 6
+                        + 4;
+        }
+        else
+        {
+            int weaponDamage = 0;
+            switch (attacks[(int)type & 15])
+            {
+            case EAttack.Slash:
+                weaponDamage = meleeData.Slash;
+                break;
+            case EAttack.Bash:
+                weaponDamage = meleeData.Bash;
+                break;
+            case EAttack.Stab:
+                weaponDamage = meleeData.Stab;
+                break;
+            }
+            maxDamage = weaponDamage + PlayerData.sData.strength / 9;
+        }
+
+        if (isEnchanted && !string.IsNullOrEmpty(enchantmentName) && enchantmentIndex >= 8) // damage enchantment
+        {
+            maxDamage += 1 + enchantmentIndex - 8;
+        }
 
         if (Magic.sMagic.IsSpellActive(Magic.ESpell.Cursed))
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- A punch now takes its damage from the Unarmed skill, which had no effect on it at all. A trained brawler's fist is worth three and a half times what it was, an untrained one half again as much, so bare hands are a way to fight rather than a last resort.
+
 - A missile now does the damage its own row in the game's data gives it, instead of a hand-written number, and the Missile skill multiplies that damage rather than being added to it. Archery is a little weaker at the top and a spell is much stronger everywhere: a fireball averaged seven points for a new mage and fourteen for a practised one, where the original asks for sixteen and a half from both.
 
 - Spells no longer get a damage bonus from the caster's skill, which the original gives to neither spells nor arrows. A fireball is a fireball whoever throws it; what the skill buys is the chance of throwing one at all.


### PR DESCRIPTION
A punch's damage was that row's three points plus a ninth of Strength, and the Unarmed skill did not enter it at all. The original picks a different sum for bare hands - two fifths of Unarmed, a sixth of Strength, and four - in which the skill is the leading term. With both at 30 the original asks for 21 where this project gave 6.

Bare-handed fighting is worth doing again, and the attack rating shown under the empty hand moves when the skill does.

Details
-------

The original does not special-case the fist. The choice of formula comes from the weapon row's own skill byte, clamped into the four melee skills: below 2 or at 6 and above becomes Unarmed. Only the fist's row falls outside - it reads 6, where the others read 3, 4 or 5 - and it is the same byte the fist's prefab already carries for the to-hit roll.

UW.EXE 0x25406, read from its prologue to the lret: the clamp is at 0x25418, the bare-handed arm at 0x2545e, the armed one at 0x25495. Both arms read Strength from the same place, byte 5 of the player's row in the creature table, which the attribute is copied into at 0x7ddee - so the new sixth and the ninth this project already had are the same number.

The maximum, before the charge scale and the damage roll:

    Unarmed  Strength   before   now
       0        30         6       9
      15        30         6      15
      30        30         6      21

Checked against the data and the executable: the four constants are decoded from the bytes rather than copied by hand, read back out of the code written here, and compared over the whole grid of skill and Strength. Row 15 is the only one of sixteen whose skill byte falls outside the melee range.

Checked in play: 102 landed punches at Unarmed 0, 11 and 23 with Strength 19. The maximum went 7, 11, 16 where it would have stayed at 5 for all three, and the average damage from 3.7 to 9.3, every line agreeing with the formula, the charge scale and the dice.