### PR TITLE
Magic: the casting roll, and critical success costs

### DIFF
--- a/Assets/Game/Scripts/Magic.cs
+++ b/Assets/Game/Scripts/Magic.cs
@@ -1094,17 +1094,10 @@ public class Magic : MonoBehaviour
             return;
         }
 
-        int cost = spells[i].cost;
-        if (crit)
-        {
-            PlayerData.sData.mana -= cost / 2;
-            bubbleTime = 3.0f;
-        }
-        else
-        {
-            PlayerData.sData.mana -= cost;
-            bubbleTime = 2.0f;
-        }
+        // The full cost either way: see the note on the critical success in
+        // TryCastFromSpellRunes(). The flag still picks the longer bubble.
+        PlayerData.sData.mana -= spells[i].cost;
+        bubbleTime = crit ? 3.0f : 2.0f;
 
         castSpells[i] = true;
         timeBeforeCanCastAgain = spells[i].cost / 3.0f / PlayerData.sData.charLevel;
@@ -1437,12 +1430,19 @@ public class Magic : MonoBehaviour
             }
             else
             {
-                int casting = Skills.GetSkill(ESkill.Casting);
+                // The original rolls Casting with five added to it against twice the circle, not
+                // against the mana cost, which is three times the circle. The margin differs by
+                // 5 + circle: six points at the first circle, thirteen at the eighth. UW.EXE
+                // 0x78ec8, read from its prologue to the lret; the roll is at 0x78f4d and calls
+                // GetResult, which is 0x30f9:0x000c, file 0x3419c. The circle here stays the one
+                // the rest of this method already uses - the cost divided by three - so that the
+                // handful of spells whose cost is wrong keep whatever circle they had.
+                int casting = Skills.GetSkill(ESkill.Casting) + 5;
                 if (Cheats.sCheats.boostCasting)
                 {
                     casting += 20;
                 }
-                Skills.ESkillTestResult result = Skills.GetResult(casting, spells[i].cost);
+                Skills.ESkillTestResult result = Skills.GetResult(casting, 2 * spells[i].circle);
                 switch (result)
                 {
                 case Skills.ESkillTestResult.CriticalFailure:
@@ -1470,7 +1470,14 @@ public class Magic : MonoBehaviour
                         break;
                     }
 
-                    PlayerData.sData.mana -= spells[i].cost / 2;
+                    // A critical success costs what any success costs. The original cannot
+                    // charge less for one: it overwrites the roll's result with the spell's
+                    // power before it comes to the mana, so by then nothing can tell the two
+                    // apart, and it takes three per circle either way (UW.EXE 0x78f99 then
+                    // 0x78fd2). The power is the same for both too, at 0x78f83 - a critical
+                    // success in the original buys nothing at all - so what is left here is
+                    // the longer bubble, which is only feedback.
+                    PlayerData.sData.mana -= spells[i].cost;
                     bubbleTime = 3.0f;
                     TryCast(i);
                     castSpells[i] = true;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - A punch now takes its damage from the Unarmed skill, which had no effect on it at all. A trained brawler's fist is worth three and a half times what it was, an untrained one half again as much, so bare hands are a way to fight rather than a last resort.
 
+- Casting a spell now rolls the way the original rolls it: five points are added to the skill, and the roll is against twice the spell's circle rather than against its mana cost. Spells go off far more often - an eighth-circle spell at full Casting never fails now, where it failed a third of the time - and the cheapest spells can no longer backfire at any skill, which in the original they never could.
+
+- A spell no longer costs half its mana when the roll comes out a critical success. The original charges the full price however well the roll went, and at high Casting nearly every cast is a critical success, so most of a practised mage's spells were going off at half price.
+
 - A missile now does the damage its own row in the game's data gives it, instead of a hand-written number, and the Missile skill multiplies that damage rather than being added to it. Archery is a little weaker at the top and a spell is much stronger everywhere: a fireball averaged seven points for a new mage and fourteen for a practised one, where the original asks for sixteen and a half from both.
 
 - Spells no longer get a damage bonus from the caster's skill, which the original gives to neither spells nor arrows. A fireball is a fireball whoever throws it; what the skill buys is the chance of throwing one at all.


### PR DESCRIPTION
Casting a spell rolled the Casting skill against the spell's mana cost. The original adds five to the skill and rolls it against twice the circle, where the cost is three times the circle, so the margin was short by 5 + circle. And a critical success was charging half the mana, where the original charges the same price however well the roll went.

Spells go off far more often, a three-mana spell can no longer backfire at any skill, and casting costs what it says it costs.

Details
-------

UW.EXE 0x78ec8, read from its prologue to the lret. The roll is at 0x78f4d and goes to GetResult at file 0x3419c; the skill it reads is P1[0x2a], which is Casting, the five is added at 0x78f49, and the difficulty is the circle doubled at 0x78f3d.

The original cannot charge less for a critical success: at 0x78f99 it overwrites the roll's result with the spell's power, and only then, at 0x78fd2, takes three per circle off the mana. The power is the same for both outcomes, so a critical success buys nothing there. Both places that charge a rune cast are changed, the direct one and the one that waits for a mouse-aimed spell to be confirmed.

The circle is taken from the cost, as the rest of the method already does, rather than from the spell's index as the original does: the two disagree only for the few spells whose cost this project has wrong, and those are a separate question.

The share of casts that go off, over the roll's thirty-one values:

    Casting  circle   before    now
      10        3       52%     77%
      20        8       35%     77%
      30        8       68%    100%

Checked against the executable: both terms are decoded from the bytes, read back out of the code written here, and the rates above recomputed from the roll's own thresholds.

Checked in play: 77 casts over two sessions, ten spells, five different circles. Every line carries the five and twice the circle, none of the cheapest casts backfired, and every cast that went off paid the full price - 39 of them critical at the roll and 7 more critical on the aim confirm, which is the second place that charges.