### PR TITLE
Combat: a critical hit from the player doubles the damage too

### DIFF
--- a/Assets/Game/Scripts/Critter.cs
+++ b/Assets/Game/Scripts/Critter.cs
@@ -3398,13 +3398,6 @@ public class Critter : UUObject
         return 0;
     }
 
-    private static int GetCriticalDamage(int damage)
-    {
-        //based on disassembly:
-        //seems to be a 50:50 chance for a crit which gives double damage. (48+(rng 0-30)) >>5
-        return damage * Random.Range(1, 3);
-    }
-
     /// <summary>
     /// The height the swing lands at: the middle of the creature's own body, which is what the
     /// original compares against the target's extent to pick a body part (UW.EXE 0x2441a).
@@ -3525,7 +3518,7 @@ public class Critter : UUObject
         int damage = Mathf.Max(2, attackDamage + strength / 5 + damageBonus);
         if (result == Skills.ESkillTestResult.CriticalSuccess)
         {
-            damage = GetCriticalDamage(damage);
+            damage = Utils.GetCriticalDamage(damage);
         }
 
         // The table value is a maximum, rolled down and then scaled by how far the creature wound

--- a/Assets/Game/Scripts/Utils.cs
+++ b/Assets/Game/Scripts/Utils.cs
@@ -223,6 +223,23 @@ public class Utils
         return Random.Range(0, 3) == 0 ? EBodyPart.Arms : EBodyPart.Torso;
     }
 
+    /// <summary>
+    /// What a critical hit does to the maximum before the dice are rolled: double it, half the
+    /// time.
+    /// </summary>
+    /// <remarks>
+    /// The original draws rand() &amp; 31, adds 48 and shifts right by 5, which is 1 for the low
+    /// sixteen values and 2 for the high sixteen - an even coin flip (UW.EXE 0x24bc3). It lands
+    /// on the nominal damage, before the roll and before the charge scale, and it lands there for
+    /// whoever swung: one routine resolves both the player's blow and a creature's, and the
+    /// critical branch sits inside it (0x24ac9, called from 0x255ca and from 0x259ee through
+    /// 0x251ac).
+    /// </remarks>
+    public static int GetCriticalDamage(int maxDamage)
+    {
+        return maxDamage * Random.Range(1, 3);
+    }
+
     public static int GetDamageRoll(int maxDamage)
     {
         int numD6 = maxDamage / 6;

--- a/Assets/Game/Scripts/WeaponBase.cs
+++ b/Assets/Game/Scripts/WeaponBase.cs
@@ -704,6 +704,16 @@ public class WeaponBase : UUObject
                 {
                     ObjectsData.MeleeData meleeData =  DataLoader.sDataLoader.objectsData.weaponStats[(int)type & 15];
                     int maxDamage = GetMaxDamage();
+                    if (res == Skills.ESkillTestResult.CriticalSuccess)
+                    {
+                        // The original resolves the player's blow and a creature's in one routine,
+                        // so the doubling that creatures already get here belongs to the player
+                        // too - it sits in the shared routine's critical branch, not in either
+                        // caller (UW.EXE 0x24ac9, reached from 0x255ca for the player and from
+                        // 0x259ee for a creature). It applies to the nominal damage, which is why
+                        // it goes before the roll and before the charge scale.
+                        maxDamage = Utils.GetCriticalDamage(maxDamage);
+                    }
                     int rolledDamage = Utils.GetDamageRoll(maxDamage);
                     int prepTime = GetChargePercent();
                     int scaledForDamage = meleeData.MinCharge +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - A spell no longer costs half its mana when the roll comes out a critical success. The original charges the full price however well the roll went, and at high Casting nearly every cast is a critical success, so most of a practised mage's spells were going off at half price.
 
+- Landing a critical hit now doubles the damage half the time, the way a critical hit from a creature already did. Against anything you comfortably outclass most of your blows are critical, so for a trained character this reads as about half again on melee damage rather than an occasional flourish.
+
 - A missile now does the damage its own row in the game's data gives it, instead of a hand-written number, and the Missile skill multiplies that damage rather than being added to it. Archery is a little weaker at the top and a spell is much stronger everywhere: a fireball averaged seven points for a new mage and fourteen for a practised one, where the original asks for sixteen and a half from both.
 
 - Spells no longer get a damage bonus from the caster's skill, which the original gives to neither spells nor arrows. A fireball is a fireball whoever throws it; what the skill buys is the chance of throwing one at all.


### PR DESCRIPTION
A critical hit landed by a creature already rolled double damage half the time, and one landed by the player did nothing at all. The original settles both directions of a melee blow in one routine and puts the doubling inside it, so the two sides were never meant to differ.

A blow that lands perfectly is worth something again, and the asymmetry that ran against the player is gone.

Details
-------

UW.EXE 0x24ac9, read from its prologue to the lret. One roll, at 0x24ba7; one critical branch, at 0x24bbe; and two callers, 0x255ca for the player's swing and 0x259ee for a creature's attack, both through 0x251ac. The multiplier is rand() & 31, plus 48, shifted right by 5 - 1 for the low sixteen values and 2 for the high sixteen, an even coin flip. Random.Range(1, 3) is the same draw, and the creature side was already written that way.

It meets the nominal damage, before the dice and before the charge scale, which is where the creature side already applies it. The helper moves to Utils beside GetDamageRoll, since the original shares it too. Fists come along; launchers do not, since their attack never reaches this code and a missile already scales its own critical.

This is not an occasional flourish. A creature's defence is one byte of its row, running from nothing to fifty with a median of seventeen, while a trained character's attack score reaches the high forties - so against anything ordinary every blow that lands is critical. For such a character the honest description is a flat rise of about half again on the melee ceiling: half again rather than double because the multiplier is a coin flip, and ceiling rather than damage because it meets the maximum before the dice are rolled under it. The creatures have been getting that all along.

Checked against the executable: the multiplier is decoded from the bytes and compared with the code written here, and the shared routine's two callers counted.

Checked in play: 33 landed blows, nineteen with an axe and fourteen bare handed, of which twelve came out critical and six of those doubled. Every critical multiplied by one or two and by nothing else, every ordinary hit left the maximum alone, and each line agreed with the dice and the charge scale. Average damage before armour was 6.9 on an ordinary hit, 9.2 on a critical that did not double and 20.7 on one that did.