### PR TITLE
Shrine: restore group mantras original skill's advancement

### DIFF
--- a/Assets/Game/Scripts/CreateCharacter.cs
+++ b/Assets/Game/Scripts/CreateCharacter.cs
@@ -104,6 +104,14 @@ public class CreateCharacter : MonoBehaviour
         PlayerData.sData.mana = 0;
         PlayerData.sData.maxMana = 0;
         PlayerData.sData.xp = 0;
+        // The original writes these two right beside the experience it has just zeroed
+        // (UW.EXE 0x6c84e and 0x6c856). They belong here rather than in the field's
+        // initialiser: PlayerData is a component that survives from one game to the next,
+        // and the value Unity has serialised in the scene wins over any initialiser, so a
+        // new character was starting with whatever the scene held - three points - and a
+        // high-water mark left over from the character before.
+        PlayerData.sData.skillPoints = 1;
+        PlayerData.sData.skillPointsXpTier = 0;
         for (int i = 0; i < 20; ++i)
         {
             PlayerData.sData.skill[i] = 0;

--- a/Assets/Game/Scripts/PlayerData.cs
+++ b/Assets/Game/Scripts/PlayerData.cs
@@ -60,7 +60,10 @@ public class PlayerData : MonoBehaviour
     public int mana;
     public int xp;
     public int charLevel = 1;
-    public int skillPoints = 3; // start with 3, I think
+    // One, not three: character creation writes a single point (UW.EXE 0x6c84e,
+    // movb $0x1, 0x52(%bx), right beside the level being set to 1 and the experience
+    // tier high-water to 0).
+    public int skillPoints = 1;
     public int skillPointsXpTier; // high-water of displayXp/300 tiers already awarded
     public bool easy;
 

--- a/Assets/Game/Scripts/Shrine.cs
+++ b/Assets/Game/Scripts/Shrine.cs
@@ -124,6 +124,9 @@ public class Shrine : UUObject
         {
             ESkill firstSkill = ESkill.Attack;
             ESkill secondSkill = ESkill.Attack;
+            // How many skills a group mantra advances belongs to the mantra: the original's three
+            // cases set it alongside the group itself (UW.EXE 0x818b6, 0x818c5, 0x818d4).
+            int groupCount = 0;
             for (int i = 0; i < 20; ++i)
             {
                 if (mantraText == skillMantras[i])
@@ -141,16 +144,19 @@ public class Shrine : UUObject
                 case "mu ahm":
                     firstSkill = ESkill.Mana;
                     secondSkill = ESkill.Casting;
+                    groupCount = 2;
                     foundMantra = true;
                     break;
                 case "om cah":
                     firstSkill = ESkill.Traps;
                     secondSkill = ESkill.Swimming;
+                    groupCount = 4;
                     foundMantra = true;
                     break;
                 case "summ ra":
                     firstSkill = ESkill.Attack;
                     secondSkill = ESkill.Missile;
+                    groupCount = 3;
                     foundMantra = true;
                     break;
                 default:
@@ -185,7 +191,7 @@ public class Shrine : UUObject
                 }
                 else
                 {
-                    if (!Skills.AdvanceSkills(firstSkill, secondSkill))
+                    if (!Skills.AdvanceSkills(firstSkill, secondSkill, groupCount))
                     {
                         Utils.PlayClip2d(badMantra);
                         return;

--- a/Assets/Game/Scripts/Skills.cs
+++ b/Assets/Game/Scripts/Skills.cs
@@ -100,11 +100,27 @@ public class Skills
         }
     }
     
+    /// <summary>
+    /// Whether this skill could still take an advance, without taking one.
+    /// </summary>
+    /// <remarks>
+    /// The ceiling is twice the governing attribute. The original is a shade looser - it fails
+    /// only once twice the attribute has fallen below the skill (UW.EXE 0x81521, a cmp followed
+    /// by jl), so a skill resting exactly on the ceiling takes one more step and ends a point
+    /// above it. That is left alone deliberately: the ceiling a player is told about is twice
+    /// the attribute, and a skill standing one past it reads as a bug rather than as fidelity.
+    /// </remarks>
+    public static bool CanAdvanceSkill(ESkill skill)
+    {
+        int curVal = GetSkill(skill);
+        return curVal < 2 * GetGoverningAttribute(skill) && curVal < 30;
+    }
+
     public static bool AdvanceSkill(ESkill skill)
     {
         int attrib = GetGoverningAttribute(skill);
         int curVal = GetSkill(skill);
-        if (curVal < 2 * attrib && curVal < 30)
+        if (CanAdvanceSkill(skill))
         {
             ++curVal;
             // The original grants this second point only when the governing attribute is not
@@ -136,39 +152,100 @@ public class Skills
         return false;
     }
 
-    public static bool AdvanceSkills(ESkill min, ESkill max)
+    /// <summary>
+    /// A group mantra: SUMM RA, MU AHM or OM CAH. How many skills it advances belongs to the
+    /// mantra and is not the same for all three (UW.EXE 0x816fd, the three cases of the jump
+    /// table at 0x819d3 set a base, a width and a count: 0/7/3, 7/3/2 and 10/10/4).
+    /// </summary>
+    /// <remarks>
+    /// The original draws blind over the whole group and tries each draw as it comes, so a draw
+    /// that lands on a skill which cannot rise is spent rather than re-rolled (the loop at
+    /// 0x81922: the count comes down on every pass, and only a successful advance is recorded).
+    /// Filtering the group first would never waste one, which is a kinder rule than the game's.
+    /// The point is spent whatever happens, and there is a message for the case where nothing
+    /// improved - the original prints it (0x81676) and reaches it the same way.
+    /// </remarks>
+    public static bool AdvanceSkills(ESkill min, ESkill max, int count)
     {
-        int eligibleCount = 0;
-        int[] eligible = new int[(int)ESkill.Swimming + 1];
-        for (int i = (int)min; i <= (int)max; i++)
+        // Deliberately kinder than the original, which spends the point whatever happens: if
+        // nothing in the group can move at all, say so and let the player keep the point. Kept
+        // as a modern convenience rather than restored to the original's behaviour.
+        bool anyCanAdvance = false;
+        for (int i = (int)min; i <= (int)max && !anyCanAdvance; i++)
         {
-            if (PlayerData.sData.skill[i] < 30)
-            {
-                eligible[eligibleCount++] = i;
-            }
+            anyCanAdvance = CanAdvanceSkill((ESkill)i);
         }
 
-        if (eligibleCount == 0)
+        if (!anyCanAdvance)
         {
-            Messages.Add(1, 27);
+            Messages.Add(1, 30); // none of your skills improved
             return false;
         }
 
-        int pick1 = eligible[Random.Range(0, eligibleCount)];
-        int pick2 = eligible[Random.Range(0, eligibleCount)];
-        ESkill skill1 = (ESkill)pick1;
-        ESkill skill2 = (ESkill)pick2;
-        AdvanceSkill(skill1);
-        AdvanceSkill(skill2);
-        Messages.Add(1, 26);
-        if (skill1 == skill2)
+        int width = max - min + 1;
+        // The original's safety counter is the group's width. It never binds on the three real
+        // mantras, where the count is always the smaller of the two, but it is what stops the
+        // loop in the original and it costs nothing to keep.
+        int attempts = width;
+        ESkill[] advanced = new ESkill[4];
+        int advancedCount = 0;
+
+        while (count > 0 && attempts-- > 0)
         {
-            Messages.Add($"{StringLoader.GetString(1, 28)}{skill1}.");
+            ESkill skill;
+            // MU AHM leans on Mana while Mana is still low: one draw in two is forced to it
+            // instead of being rolled. The original tests the group's base, the skill against 8,
+            // and a single bit of rand().
+            if (min == ESkill.Mana && GetSkill(ESkill.Mana) < 8 && Random.Range(0, 2) == 0)
+            {
+                skill = ESkill.Mana;
+            }
+            else
+            {
+                skill = (ESkill)((int)min + Random.Range(0, width));
+            }
+
+            if (AdvanceSkill(skill) && advancedCount < advanced.Length)
+            {
+                advanced[advancedCount++] = skill;
+            }
+
+            count--;
+        }
+
+        if (advancedCount == 0)
+        {
+            Messages.Add(1, 30); // none of your skills improved
         }
         else
         {
-            Messages.Add($"{StringLoader.GetString(1, 29)}{skill1} and {skill2}.");
+            // When every advance landed on the same skill, and there was more than one, say it
+            // went up greatly - the wording the single-skill mantras use for their two attempts.
+            bool allTheSame = true;
+            for (int i = 1; i < advancedCount; i++)
+            {
+                allTheSame &= advanced[i] == advanced[0];
+            }
+
+            if (allTheSame && advancedCount > 1)
+            {
+                Messages.Add($"{StringLoader.GetString(1, 28)}{advanced[0]}.");
+            }
+            else
+            {
+                string list = "";
+                for (int i = 0; i < advancedCount; i++)
+                {
+                    if (i > 0)
+                    {
+                        list += (i == advancedCount - 1) ? " and " : ", ";
+                    }
+                    list += advanced[i];
+                }
+                Messages.Add($"{StringLoader.GetString(1, 29)}{list}.");
+            }
         }
+
         --PlayerData.sData.skillPoints;
         return true;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- The three group mantras at a shrine now advance as many skills as the original advances them: three for SUMM RA and four for OM CAH, where every group mantra used to advance two. OM CAH is once more the most generous thing a shrine offers, instead of being worth less than chanting a single skill's mantra.
+
+- A shrine no longer says it has improved skills that it has not, and it will not take the point when there is nothing in the group left to raise. MU AHM now leans towards Mana while Mana is still low, as the original has it.
+
+- A new character starts with one skill point instead of three, which is what the original grants.
+
 - A punch now takes its damage from the Unarmed skill, which had no effect on it at all. A trained brawler's fist is worth three and a half times what it was, an untrained one half again as much, so bare hands are a way to fight rather than a last resort.
 
 - Casting a spell now rolls the way the original rolls it: five points are added to the skill, and the roll is against twice the spell's circle rather than against its mana cost. Spells go off far more often - an eighth-circle spell at full Casting never fails now, where it failed a third of the time - and the cheapest spells can no longer backfire at any skill, which in the original they never could.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ I removed a number of store-bought assets before pushing this to github, so it m
   - gamepad support
   - three ratings added to the inventory panel: attack by the weapon hand, defence and armour by the shield hand
   - clearer attack feedback: the charge cursor stays dark until a release would actually land a swing, then lights up and fills
+  - a shrine will not take a skill point when nothing it could raise can rise, and it names only the skills that actually improved
 


### PR DESCRIPTION
Group mantras - SUMM RA, MU AHM, OM CAH - advanced two skills whatever was chanted. The original gives each of the three its own count: SUMM RA three of the seven Strength skills, MU AHM two of the three Intellect ones, OM CAH four of the ten Dexterity ones.

Since every mantra costs the same single point, OM CAH was worth less than chanting a single skill's mantra, which advances one skill twice. In the original it is the most generous thing a shrine offers.

The chant also claimed more than it did: it named both skills it drew whether or not either rose, so a skill already at its ceiling was announced as improved.

Details
-------

Original behaviour in UW.EXE is 0x816fd, the cases at 0x818b6, 0x818c5 and 0x818d4, reached through the jump table at 0x819d3.

How the original picks, read from the loop at 0x81922:

- it draws blind over the whole group and tries each draw as it comes. A draw that lands on a skill which cannot rise is spent, not re-rolled, so a chant late in the game raises fewer skills than its count.
- MU AHM leans on Mana: while the Mana skill is below 8, one draw in two is forced to it rather than rolled, which takes Mana from a third of the draws to two thirds until it reaches 8.
- the announcement lists the skills that actually rose, joined with commas and a final "and".

Two deliberate departures from the original. It spends the point whatever happens, and this keeps it when nothing in the group can rise at all - the README lists that among the modern conveniences. And where every advance landed on the same skill the original names it once per advance, while this says the skill advanced greatly, the wording a single-skill mantra uses.

Starting skill points go from three to one, written where character creation resets the rest of the character rather than left to the field's initialiser: PlayerData is a component whose value is serialised in the scene, and that value wins, so a new character was starting with three however the field was declared.

Checked in play over 137 chants. The counts come out exactly three, two and four while the group has room, and fall only where a skill has reached its ceiling: seven chants raised nothing and twenty-seven raised one, which is the wasted draw above. The Mana lean was measured on a character starting from zero - fifteen of twenty-four draws went to Mana against the eight expected without it.